### PR TITLE
Increase Nix store GC size limit to 20GB in workflows

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
+          gc-max-store-size-linux: 20G
       - name: Build binary
         run: nix build
 
@@ -39,7 +39,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
+          gc-max-store-size-linux: 20G
       - name: Publish crates.io
         run: |
           nix develop --command cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
+          gc-max-store-size-linux: 20G
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit


### PR DESCRIPTION
Increased gc-max-store-size-linux from 1G to 20G in both CI and CD workflows to prevent premature garbage collection of Nix store artifacts, which should improve build reliability and performance.