### PR TITLE
Update documentation to reflect 11 MCP tools and add symbol APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude
 *.log
 .lazy.lua
+.direnv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ with code in this repository.
 
 This is a Rust-based Model Context Protocol (MCP) server that provides AI
 assistants with programmatic access to Neovim instances. The server supports
-both Unix socket/named pipe and TCP connections, implements nine core MCP
+both Unix socket/named pipe and TCP connections, implements eleven core MCP
 tools for Neovim interaction, and provides diagnostic resources through the
 `nvim-diagnostics://` URI scheme. The project uses Rust 2024 edition and
 focuses on async/concurrent operations with proper error handling throughout.
@@ -78,7 +78,7 @@ The codebase follows a modular architecture with clear separation of concerns:
   - Error conversion between `NeovimError` and `McpError`
 
 - **`src/server/tools.rs`**: MCP tool implementations
-  - Implements eight MCP tools using the `#[tool]` attribute
+  - Implements eleven MCP tools using the `#[tool]` attribute
   - Contains parameter structs for tool requests
   - Focuses purely on MCP tool logic and protocol implementation
   - Clean separation from core infrastructure
@@ -170,13 +170,18 @@ The server provides these tools (implemented with `#[tool]` attribute):
 3. **`disconnect`**: Disconnect from specific Neovim instance by `connection_id`
 
 **Connection-Aware Tools** (require `connection_id` parameter):
-4. **`list_buffers`**: List all open buffers for specific connection
-5. **`exec_lua`**: Execute arbitrary Lua code in specific Neovim instance
-6. **`buffer_diagnostics`**: Get diagnostics for specific buffer on specific connection
-7. **`lsp_clients`**: Get workspace LSP clients for specific connection
-8. **`buffer_code_actions`**: Get LSP code actions for buffer range on specific connection
-9. **`buffer_hover`**: Get LSP hover information for symbols at cursor
+
+1. **`list_buffers`**: List all open buffers for specific connection
+2. **`exec_lua`**: Execute arbitrary Lua code in specific Neovim instance
+3. **`buffer_diagnostics`**: Get diagnostics for specific buffer on specific connection
+4. **`lsp_clients`**: Get workspace LSP clients for specific connection
+5. **`buffer_code_actions`**: Get LSP code actions for buffer range on specific connection
+6. **`buffer_hover`**: Get LSP hover information for symbols at cursor
    position on specific connection
+7. **`document_symbols`**: Get document symbols for specific buffer on
+   specific connection
+8. **`workspace_symbols`**: Search workspace symbols by query on specific
+   connection
 
 ### MCP Resources
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Once both the MCP server and Neovim are running, here's a typical workflow:
 
 ## Available Tools
 
-The server provides these MCP tools for interacting with Neovim:
+The server provides 11 MCP tools for interacting with Neovim:
 
 ### Connection Management
 
@@ -166,6 +166,14 @@ establishment phase:
 - **`buffer_hover`**: Get symbol hover information via LSP
   - Parameters: `connection_id` (string), `id` (number), `lsp_client_name`
     (string), `line` (number), `character` (number) (all positions are 0-indexed)
+
+- **`document_symbols`**: Get document symbols for a buffer
+  - Parameters: `connection_id` (string), `id` (number), `lsp_client_name`
+    (string) - Buffer ID and LSP client name
+
+- **`workspace_symbols`**: Search workspace symbols by query
+  - Parameters: `connection_id` (string), `lsp_client_name` (string), `query`
+    (string) - Search query for filtering symbols
 
 #### Code Execution
 

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -4,7 +4,7 @@
 
 ### Tools
 
-The server provides 9 MCP tools for interacting with Neovim instances:
+The server provides 11 MCP tools for interacting with Neovim instances:
 
 #### Connection Management
 
@@ -83,6 +83,22 @@ All tools below require a `connection_id` parameter from connection establishmen
   - **Returns**: Object with hover information including documentation and type details
   - **Usage**: Get detailed information about symbols, functions, variables at
     cursor position
+
+- **`document_symbols`**: Get document symbols for specific buffer
+  - **Parameters**:
+    - `connection_id` (string): Target Neovim instance ID
+    - `id` (number): Buffer ID from list_buffers
+    - `lsp_client_name` (string): LSP client name from lsp_clients
+  - **Returns**: Array of document symbol objects with names, kinds, and ranges
+  - **Usage**: Navigate and understand code structure within a specific file
+
+- **`workspace_symbols`**: Search workspace symbols by query
+  - **Parameters**:
+    - `connection_id` (string): Target Neovim instance ID
+    - `lsp_client_name` (string): LSP client name from lsp_clients
+    - `query` (string): Search query to filter symbols (empty string returns all)
+  - **Returns**: Array of workspace symbol objects with names, locations, and kinds
+  - **Usage**: Find symbols across the entire workspace for navigation and code exploration
 
 ### Resources
 
@@ -200,8 +216,19 @@ Connection-scoped diagnostic resources using `nvim-diagnostics://` scheme:
 4. Request code actions for interesting ranges (reuse connection_id)
 5. Use buffer_hover to get detailed symbol information at cursor positions
    (reuse connection_id)
-6. Combine information for comprehensive analysis
-7. Maintain connection for iterative code exploration
+6. Use document_symbols to understand file structure (reuse connection_id)
+7. Use workspace_symbols to find related code across project (reuse connection_id)
+8. Combine information for comprehensive analysis
+9. Maintain connection for iterative code exploration
+
+#### Symbol Navigation Workflow
+
+1. Connect to Neovim instance (cache connection_id)
+2. Get available LSP clients (reuse connection_id)
+3. Use workspace_symbols with search query to find symbols across project
+4. Use document_symbols to understand structure of specific files
+5. Navigate to symbol locations using returned position information
+6. Keep connection active for continued navigation
 
 #### Multi-Instance Management
 


### PR DESCRIPTION
- Update tool count from 9 to 11 across documentation files
- Add documentation for document_symbols and workspace_symbols tools
- Add .direnv to .gitignore for Nix development environment
- Include symbol navigation workflow in instructions