### PR TITLE
Add build-time metadata with Git information and timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "blake3",
+ "chrono",
  "clap",
  "dashmap",
  "futures 0.3.31",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ blake3 = "1.5"
 tracing-test = "0.2"
 rand = "0.9.2"
 tempfile = "3.0"
+
+[build-dependencies]
+chrono = { version = "0.4" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,66 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    // Get Git commit SHA - env var overrides .git
+    let git_commit_sha = env::var("GIT_COMMIT_SHA")
+        .unwrap_or_else(|_| get_git_commit_sha().unwrap_or_else(|| "unknown".to_string()));
+
+    println!("cargo:rustc-env=GIT_COMMIT_SHA={}", git_commit_sha);
+
+    // Get Git dirty status - env var overrides .git status
+    let git_dirty = env::var("GIT_DIRTY")
+        .unwrap_or_else(|_| get_git_dirty_status().unwrap_or_else(|| "unknown".to_string()));
+
+    println!("cargo:rustc-env=GIT_DIRTY={}", git_dirty);
+
+    // Get build time - SOURCE_DATE_EPOCH overrides current time
+    let build_time = env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|epoch| epoch.parse::<i64>().ok())
+        .and_then(|timestamp| chrono::DateTime::from_timestamp(timestamp, 0))
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+    println!("cargo:rustc-env=BUILT_TIME_UTC={}", build_time);
+
+    // Tell cargo to rerun this script if .git/HEAD changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    // Also watch the current branch ref file for new commits
+    if let Ok(head_content) = std::fs::read_to_string(".git/HEAD") {
+        if let Some(branch_ref) = head_content.strip_prefix("ref: ").map(|s| s.trim()) {
+            println!("cargo:rerun-if-changed=.git/{}", branch_ref);
+        }
+    }
+    // Also rerun if env vars change
+    println!("cargo:rerun-if-env-changed=GIT_COMMIT_SHA");
+    println!("cargo:rerun-if-env-changed=GIT_DIRTY");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+}
+
+fn get_git_commit_sha() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+fn get_git_dirty_status() -> Option<String> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let is_dirty = !output.stdout.is_empty();
+        Some(if is_dirty { "true" } else { "false" }.to_string())
+    } else {
+        None
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -27,10 +27,10 @@ fn main() {
     println!("cargo:rerun-if-changed=.git/HEAD");
 
     // Also watch the current branch ref file for new commits
-    if let Ok(head_content) = std::fs::read_to_string(".git/HEAD") {
-        if let Some(branch_ref) = head_content.strip_prefix("ref: ").map(|s| s.trim()) {
-            println!("cargo:rerun-if-changed=.git/{}", branch_ref);
-        }
+    if let Ok(head_content) = std::fs::read_to_string(".git/HEAD")
+        && let Some(branch_ref) = head_content.strip_prefix("ref: ").map(|s| s.trim())
+    {
+        println!("cargo:rerun-if-changed=.git/{}", branch_ref);
     }
     // Also rerun if env vars change
     println!("cargo:rerun-if-env-changed=GIT_COMMIT_SHA");

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,8 @@
               gopls
             ];
             shellHook = ''
+              # Unset SOURCE_DATE_EPOCH to prevent reproducible build timestamps during development.
+              # This allows timestamps to reflect the current time, which is useful for development workflows.
               unset SOURCE_DATE_EPOCH
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,17 @@
           ];
         };
         lib = pkgs.lib;
+        git_dirty =
+          if (self.sourceInfo ? rev)
+          then "false"
+          else "true";
+        git_commit_sha =
+          self.sourceInfo.rev or (
+            if (self.sourceInfo ? dirtyRev)
+            then lib.strings.removeSuffix "-dirty" self.sourceInfo.dirtyRev
+            else "unknown"
+          );
+        git_last_modified = toString self.sourceInfo.lastModified or "unknown";
       in {
         devShells = {
           default = pkgs.mkShell {
@@ -46,9 +57,6 @@
                 "rustfmt"
               ])
             ];
-            buildInputs = with pkgs; [
-              libiconv
-            ];
             packages = with pkgs; [
               # Development
               rust-analyzer-nightly
@@ -60,6 +68,9 @@
               go
               gopls
             ];
+            shellHook = ''
+              unset SOURCE_DATE_EPOCH
+            '';
           };
         };
         packages = rec {
@@ -81,6 +92,11 @@
                 mainProgram = name;
               };
               src = ./.;
+              env = {
+                GIT_COMMIT_SHA = git_commit_sha;
+                GIT_DIRTY = git_dirty;
+                SOURCE_DATE_EPOCH = git_last_modified;
+              };
               cargoLock = {lockFile = ./Cargo.lock;};
               checkFlags = [
                 "--skip=integration_tests"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,35 @@
 use clap::Parser;
 use rmcp::{ServiceExt, transport::stdio};
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::OnceLock};
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
 use nvim_mcp::NeovimMcpServer;
 
+static LONG_VERSION: OnceLock<String> = OnceLock::new();
+
+fn long_version() -> &'static str {
+    LONG_VERSION
+        .get_or_init(|| {
+            // This closure is executed only once, on the first call to get_or_init
+            let dirty = if env!("GIT_DIRTY") == "true" {
+                "[dirty]"
+            } else {
+                ""
+            };
+            format!(
+                "{} (sha:{:?}, build_time:{:?}){}",
+                env!("CARGO_PKG_VERSION"),
+                env!("GIT_COMMIT_SHA"),
+                env!("BUILT_TIME_UTC"),
+                dirty
+            )
+        })
+        .as_str()
+}
+
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, long_version=long_version(), about, long_about = None)]
 struct Cli {
     /// Path to the log file. If not specified, logs to stderr
     #[arg(long)]


### PR DESCRIPTION
- Add build.rs for compile-time Git metadata embedding
- Include Git commit SHA, dirty status, and build timestamp
- Support reproducible builds via SOURCE_DATE_EPOCH
- Add chrono dependency for timestamp formatting
- Update Nix flake with proper Git metadata handling
- Add long version display with Git and build information