### PR TITLE
Reduce Nix cache max store size from 20G to 15G

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 20G
+          gc-max-store-size-linux: 15G
 
       - name: Setup nix develop env
         run: |
@@ -49,7 +49,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 20G
+          gc-max-store-size-linux: 15G
 
       - name: Setup nix develop env
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 20G
+          gc-max-store-size-linux: 15G
 
       - name: Cache pre-commit hooks
         uses: actions/cache@v4


### PR DESCRIPTION
Lower garbage collection threshold in GitHub Actions workflows to optimize CI/CD resource usage and prevent cache size issues.