### PR TITLE
Add lsp_declaration tool for symbol declaration navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### New Features
+
+- **LSP Declaration Support**: Added `lsp_declaration` tool for finding symbol
+  declarations with universal document identification
+
+### New Tools (1 additional, 19 total)
+
+**Enhanced LSP Integration:**
+
+- `lsp_declaration` - Get LSP declaration with universal document identification
+  (buffer IDs, project paths, absolute paths)
+
 ## [v0.3.0] - 2025-08-15
 
 ### New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ This modular architecture provides several advantages:
 
 ### Available MCP Tools
 
-The server provides these 18 tools (implemented with `#[tool]` attribute):
+The server provides these 19 tools (implemented with `#[tool]` attribute):
 
 **Connection Management:**
 
@@ -194,6 +194,7 @@ The server provides these 18 tools (implemented with `#[tool]` attribute):
 12. **`lsp_definition`**: Get LSP definition with universal document identification
 13. **`lsp_type_definition`**: Get LSP type definition with universal document identification
 14. **`lsp_implementations`**: Get LSP implementations with universal document identification
+15. **`lsp_declaration`**: Get LSP declaration with universal document identification
 
 ### Universal Document Identifier System
 
@@ -212,7 +213,8 @@ This system enables LSP operations on files that may not be open in Neovim
 buffers, providing
 enhanced flexibility for code analysis and navigation. The universal LSP tools
 (`lsp_code_actions`, `lsp_hover`, `lsp_document_symbols`, `lsp_references`,
-`lsp_definition`, `lsp_type_definition`, `lsp_implementations`) accept any of these
+`lsp_definition`, `lsp_type_definition`, `lsp_implementations`,
+`lsp_declaration`) accept any of these
 document identifier types.
 
 ### MCP Resources

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Once both the MCP server and Neovim are running, here's a typical workflow:
 
 ## Available Tools
 
-The server provides 18 MCP tools for interacting with Neovim:
+The server provides 19 MCP tools for interacting with Neovim:
 
 ### Connection Management
 
@@ -208,6 +208,13 @@ establishment phase:
     `lsp_client_name` (string), `line` (number), `character` (number)
     (all positions are 0-indexed)
   - Returns: Implementation result supporting Location arrays, LocationLink arrays,
+    or null responses
+
+- **`lsp_declaration`**: Get LSP declaration with universal document identification
+  - Parameters: `connection_id` (string), `document` (DocumentIdentifier),
+    `lsp_client_name` (string), `line` (number), `character` (number)
+    (all positions are 0-indexed)
+  - Returns: Declaration result supporting Location arrays, LocationLink arrays,
     or null responses
 
 ### Universal Document Identifier

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -4,7 +4,7 @@
 
 ### Tools
 
-The server provides 18 MCP tools for interacting with Neovim instances:
+The server provides 19 MCP tools for interacting with Neovim instances:
 
 #### Connection Management
 
@@ -173,6 +173,19 @@ All tools below require a `connection_id` parameter from connection establishmen
   - **Usage**: Find interface/abstract class implementations with universal
     document identification for enhanced code navigation
 
+- **`lsp_declaration`**: Get LSP declaration with universal document identification
+  - **Parameters**:
+    - `connection_id` (string): Target Neovim instance ID
+    - `document` (DocumentIdentifier): Universal document identifier
+      (BufferId, ProjectRelativePath, or AbsolutePath)
+    - `lsp_client_name` (string): LSP client name from lsp_clients
+    - `line` (number): Symbol position line (0-indexed)
+    - `character` (number): Symbol position character (0-indexed)
+  - **Returns**: Declaration result supporting Location arrays, LocationLink
+    arrays, or null responses
+  - **Usage**: Find symbol declarations with universal document identification
+    for enhanced code navigation
+
 ### Resources
 
 ### Universal Document Identifier System
@@ -193,7 +206,8 @@ This system enables LSP operations on files that may not be open in Neovim buffe
 providing enhanced flexibility for code analysis and navigation. The universal LSP
 tools (`lsp_code_actions`, `lsp_hover`, `lsp_document_symbols`,
 `lsp_references`, `lsp_definition`, `lsp_type_definition`,
-`lsp_implementations`) accept any of these document identifier types.
+`lsp_implementations`, `lsp_declaration`) accept any of these document identifier
+types.
 
 ### MCP Resources
 

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,8 @@
               lua-language-server
               go
               gopls
+              zig
+              zls
             ];
             shellHook = ''
               # Unset SOURCE_DATE_EPOCH to prevent reproducible build timestamps during development.

--- a/src/neovim/lua/lsp_declaration.lua
+++ b/src/neovim/lua/lsp_declaration.lua
@@ -1,0 +1,27 @@
+local clients = vim.lsp.get_clients()
+local client_name, params_raw, timeout_ms = unpack({ ... })
+local client
+for _, v in ipairs(clients) do
+    if v.name == client_name then
+        client = v
+    end
+end
+if client == nil then
+    return vim.json.encode({
+        err_msg = string.format("LSP client %s not found", vim.json.encode(client_name)),
+    })
+end
+
+local params = vim.json.decode(params_raw)
+local result, err = client:request_sync("textDocument/declaration", params, timeout_ms)
+if err then
+    return vim.json.encode({
+        err_msg = string.format(
+            "LSP client %s request_sync error: %s",
+            vim.json.encode(client_name),
+            vim.json.encode(err)
+        ),
+    })
+end
+
+return vim.json.encode(result)

--- a/src/neovim/testdata/cfg_lsp.lua
+++ b/src/neovim/testdata/cfg_lsp.lua
@@ -18,3 +18,10 @@ vim.lsp.config["gopls"] = {
     root_markers = { ".root" },
 }
 vim.lsp.enable("gopls")
+
+vim.lsp.config["zls"] = {
+    cmd = { "zls" },
+    filetypes = { "zig" },
+    root_markers = { ".root" },
+}
+vim.lsp.enable("zls")

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -183,6 +183,24 @@ pub struct ImplementationParams {
     pub character: u64,
 }
 
+/// Declaration parameters
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DeclarationParams {
+    /// Unique identifier for the target Neovim instance
+    pub connection_id: String,
+    /// Universal document identifier
+    // Supports both string and struct deserialization.
+    // Compatible with Claude Code when using subscription.
+    #[serde(deserialize_with = "string_or_struct")]
+    pub document: DocumentIdentifier,
+    /// Lsp client name
+    pub lsp_client_name: String,
+    /// Symbol position, line number starts from 0
+    pub line: u64,
+    /// Symbol position, character number starts from 0
+    pub character: u64,
+}
+
 /// Code action resolve parameters
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ResolveCodeActionParams {
@@ -539,6 +557,26 @@ impl NeovimMcpServer {
         Ok(CallToolResult::success(vec![Content::json(
             implementation,
         )?]))
+    }
+
+    #[tool(description = "Get LSP declaration")]
+    #[instrument(skip(self))]
+    pub async fn lsp_declaration(
+        &self,
+        Parameters(DeclarationParams {
+            connection_id,
+            document,
+            lsp_client_name,
+            line,
+            character,
+        }): Parameters<DeclarationParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let client = self.get_connection(&connection_id)?;
+        let position = Position { line, character };
+        let declaration = client
+            .lsp_declaration(&lsp_client_name, document, position)
+            .await?;
+        Ok(CallToolResult::success(vec![Content::json(declaration)?]))
     }
 
     #[tool(description = "Resolve a code action that may have incomplete data")]


### PR DESCRIPTION
## Summary

- Implement `lsp_declaration` tool following the same pattern as `lsp_definition`
- Add comprehensive integration tests and documentation updates
- Increase total tool count from 18 to 19 tools

## Implementation

- Added `lsp_declaration` tool with universal document identification support
- Uses LSP `textDocument/declaration` method to navigate to symbol declarations
- Includes parameter structure, client trait method, implementation, and Lua script
- Added integration test with Go code and gopls language server
- Updated all documentation files (README, CLAUDE.md, docs, CHANGELOG)