### PR TITLE
Add LSP rename functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- **LSP Symbol Renaming**: Added `lsp_rename` tool for renaming symbols across
+  workspace with optional prepare rename validation
 - **LSP Declaration Support**: Added `lsp_declaration` tool for finding symbol
   declarations with universal document identification
 
-### New Tools (1 additional, 19 total)
+### New Tools (2 additional, 20 total)
 
 **Enhanced LSP Integration:**
 
+- `lsp_rename` - Rename symbol across workspace using LSP with optional
+  validation via prepare rename (buffer IDs, project paths, absolute paths)
 - `lsp_declaration` - Get LSP declaration with universal document identification
   (buffer IDs, project paths, absolute paths)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ with code in this repository.
 
 This is a Rust-based Model Context Protocol (MCP) server that provides AI
 assistants with programmatic access to Neovim instances. The server supports
-both Unix socket/named pipe and TCP connections, implements eleven core MCP
+both Unix socket/named pipe and TCP connections, implements 20 core MCP
 tools for Neovim interaction, and provides diagnostic resources through the
 `nvim-diagnostics://` URI scheme. The project uses Rust 2024 edition and
 focuses on async/concurrent operations with proper error handling throughout.
@@ -78,7 +78,7 @@ The codebase follows a modular architecture with clear separation of concerns:
   - Error conversion between `NeovimError` and `McpError`
 
 - **`src/server/tools.rs`**: MCP tool implementations
-  - Implements eleven MCP tools using the `#[tool]` attribute
+  - Implements 20 MCP tools using the `#[tool]` attribute
   - Contains parameter structs for tool requests
   - Focuses purely on MCP tool logic and protocol implementation
   - Clean separation from core infrastructure
@@ -161,7 +161,7 @@ This modular architecture provides several advantages:
 
 ### Available MCP Tools
 
-The server provides these 19 tools (implemented with `#[tool]` attribute):
+The server provides these 20 tools (implemented with `#[tool]` attribute):
 
 **Connection Management:**
 
@@ -195,6 +195,7 @@ The server provides these 19 tools (implemented with `#[tool]` attribute):
 13. **`lsp_type_definition`**: Get LSP type definition with universal document identification
 14. **`lsp_implementations`**: Get LSP implementations with universal document identification
 15. **`lsp_declaration`**: Get LSP declaration with universal document identification
+16. **`lsp_rename`**: Rename symbol across workspace using LSP
 
 ### Universal Document Identifier System
 
@@ -214,7 +215,7 @@ buffers, providing
 enhanced flexibility for code analysis and navigation. The universal LSP tools
 (`lsp_code_actions`, `lsp_hover`, `lsp_document_symbols`, `lsp_references`,
 `lsp_definition`, `lsp_type_definition`, `lsp_implementations`,
-`lsp_declaration`) accept any of these
+`lsp_declaration`, `lsp_rename`) accept any of these
 document identifier types.
 
 ### MCP Resources

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Once both the MCP server and Neovim are running, here's a typical workflow:
 
 ## Available Tools
 
-The server provides 19 MCP tools for interacting with Neovim:
+The server provides 20 MCP tools for interacting with Neovim:
 
 ### Connection Management
 
@@ -216,6 +216,13 @@ establishment phase:
     (all positions are 0-indexed)
   - Returns: Declaration result supporting Location arrays, LocationLink arrays,
     or null responses
+
+- **`lsp_rename`**: Rename symbol across workspace using LSP
+  - Parameters: `connection_id` (string), `document` (DocumentIdentifier),
+    `lsp_client_name` (string), `line` (number), `character` (number),
+    `new_name` (string), `prepare_first` (boolean, optional)
+    (all positions are 0-indexed)
+  - Returns: WorkspaceEdit with file changes or validation errors
 
 ### Universal Document Identifier
 

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -4,7 +4,7 @@
 
 ### Tools
 
-The server provides 19 MCP tools for interacting with Neovim instances:
+The server provides 20 MCP tools for interacting with Neovim instances:
 
 #### Connection Management
 
@@ -186,6 +186,21 @@ All tools below require a `connection_id` parameter from connection establishmen
   - **Usage**: Find symbol declarations with universal document identification
     for enhanced code navigation
 
+- **`lsp_rename`**: Rename symbol across workspace using LSP
+  - **Parameters**:
+    - `connection_id` (string): Target Neovim instance ID
+    - `document` (DocumentIdentifier): Universal document identifier
+      (BufferId, ProjectRelativePath, or AbsolutePath)
+    - `lsp_client_name` (string): LSP client name from lsp_clients
+    - `line` (number): Symbol position line (0-indexed)
+    - `character` (number): Symbol position character (0-indexed)
+    - `new_name` (string): New name for the symbol
+    - `prepare_first` (boolean, optional): Whether to run prepare rename first
+      for validation (default: true)
+  - **Returns**: WorkspaceEdit with file changes or validation errors
+  - **Usage**: Rename symbols across workspace with optional validation via
+    prepare rename
+
 ### Resources
 
 ### Universal Document Identifier System
@@ -206,8 +221,8 @@ This system enables LSP operations on files that may not be open in Neovim buffe
 providing enhanced flexibility for code analysis and navigation. The universal LSP
 tools (`lsp_code_actions`, `lsp_hover`, `lsp_document_symbols`,
 `lsp_references`, `lsp_definition`, `lsp_type_definition`,
-`lsp_implementations`, `lsp_declaration`) accept any of these document identifier
-types.
+`lsp_implementations`, `lsp_declaration`, `lsp_rename`) accept any of these
+document identifier types.
 
 ### MCP Resources
 

--- a/src/neovim/lua/lsp_prepare_rename.lua
+++ b/src/neovim/lua/lsp_prepare_rename.lua
@@ -1,0 +1,27 @@
+local clients = vim.lsp.get_clients()
+local client_name, params_raw, timeout_ms, bufnr = unpack({ ... })
+local client
+for _, v in ipairs(clients) do
+    if v.name == client_name then
+        client = v
+    end
+end
+if client == nil then
+    return vim.json.encode({
+        err_msg = string.format("LSP client %s not found", vim.json.encode(client_name)),
+    })
+end
+
+local params = vim.json.decode(params_raw)
+local result, err = client:request_sync("textDocument/prepareRename", params, timeout_ms, bufnr)
+if err then
+    return vim.json.encode({
+        err_msg = string.format(
+            "LSP client %s request_sync error: %s",
+            vim.json.encode(client_name),
+            vim.json.encode(err)
+        ),
+    })
+end
+
+return vim.json.encode(result)

--- a/src/neovim/lua/lsp_rename.lua
+++ b/src/neovim/lua/lsp_rename.lua
@@ -1,0 +1,27 @@
+local clients = vim.lsp.get_clients()
+local client_name, params_raw, timeout_ms, bufnr = unpack({ ... })
+local client
+for _, v in ipairs(clients) do
+    if v.name == client_name then
+        client = v
+    end
+end
+if client == nil then
+    return vim.json.encode({
+        err_msg = string.format("LSP client %s not found", vim.json.encode(client_name)),
+    })
+end
+
+local params = vim.json.decode(params_raw)
+local result, err = client:request_sync("textDocument/rename", params, timeout_ms, bufnr)
+if err then
+    return vim.json.encode({
+        err_msg = string.format(
+            "LSP client %s request_sync error: %s",
+            vim.json.encode(client_name),
+            vim.json.encode(err)
+        ),
+    })
+end
+
+return vim.json.encode(result)

--- a/src/neovim/mod.rs
+++ b/src/neovim/mod.rs
@@ -6,8 +6,8 @@ mod error;
 pub mod integration_tests;
 
 pub use client::{
-    CodeAction, DocumentIdentifier, NeovimClient, NeovimClientTrait, Position, Range,
-    WorkspaceEdit, string_or_struct,
+    CodeAction, DocumentIdentifier, NeovimClient, NeovimClientTrait, Position, PrepareRenameResult,
+    Range, WorkspaceEdit, string_or_struct,
 };
 
 pub use error::NeovimError;


### PR DESCRIPTION
## Summary
- Add `lsp_rename` tool for renaming symbols across workspace using LSP
- Implement `RenameParams` struct for MCP tool parameters
- Add proper error handling and validation for rename operations
- Update integration tests to cover the new rename functionality