### PR TITLE
Add lsp_range_formatting tool for document range formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- **LSP Document Range Formatting**: Added `lsp_range_formatting` tool for
+  formatting specific ranges in documents using LSP with support for LSP 3.15.0+
+  formatting preferences
 - **LSP Document Formatting**: Added `lsp_formatting` tool for formatting documents
   using LSP with support for LSP 3.15.0+ formatting preferences
 - **LSP Symbol Renaming**: Added `lsp_rename` tool for renaming symbols across
@@ -19,10 +22,13 @@ All notable changes to this project will be documented in this file.
 - **LSP Declaration Support**: Added `lsp_declaration` tool for finding symbol
   declarations with universal document identification
 
-### New Tools (3 additional, 21 total)
+### New Tools (4 additional, 22 total)
 
 **Enhanced LSP Integration:**
 
+- `lsp_range_formatting` - Format a specific range in a document using LSP with
+  support for LSP 3.15.0+ formatting preferences and optional auto-apply
+  (buffer IDs, project paths, absolute paths)
 - `lsp_formatting` - Format document using LSP with support for LSP 3.15.0+
   formatting preferences and optional auto-apply (buffer IDs, project paths,
   absolute paths)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ This modular architecture provides several advantages:
 
 ### Available MCP Tools
 
-The server provides these 21 tools (implemented with `#[tool]` attribute):
+The server provides these 22 tools (implemented with `#[tool]` attribute):
 
 **Connection Management:**
 
@@ -197,6 +197,7 @@ The server provides these 21 tools (implemented with `#[tool]` attribute):
 15. **`lsp_declaration`**: Get LSP declaration with universal document identification
 16. **`lsp_rename`**: Rename symbol across workspace using LSP
 17. **`lsp_formatting`**: Format document using LSP with optional auto-apply
+18. **`lsp_range_formatting`**: Format a specific range in a document using LSP
 
 ### Universal Document Identifier System
 
@@ -216,7 +217,8 @@ buffers, providing
 enhanced flexibility for code analysis and navigation. The universal LSP tools
 (`lsp_code_actions`, `lsp_hover`, `lsp_document_symbols`, `lsp_references`,
 `lsp_definition`, `lsp_type_definition`, `lsp_implementations`,
-`lsp_declaration`, `lsp_rename`, `lsp_formatting`) accept any of these
+`lsp_declaration`, `lsp_rename`, `lsp_formatting`, `lsp_range_formatting`) accept
+any of these
 document identifier types.
 
 ### MCP Resources

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Once both the MCP server and Neovim are running, here's a typical workflow:
 
 ## Available Tools
 
-The server provides 21 MCP tools for interacting with Neovim:
+The server provides 22 MCP tools for interacting with Neovim:
 
 ### Connection Management
 
@@ -226,11 +226,19 @@ establishment phase:
 
 - **`lsp_formatting`**: Format document using LSP
   - Parameters: `connection_id` (string), `document` (DocumentIdentifier),
-    `lsp_client_name` (string), `formatting_options` (FormattingOptions, optional),
-    `auto_apply` (boolean, optional) (all positions are 0-indexed)
+    `lsp_client_name` (string), `options` (FormattingOptions),
+    `apply_edits` (boolean, optional) (all positions are 0-indexed)
   - Returns: Array of TextEdit objects or success confirmation if auto-applied
   - Notes: Supports LSP 3.15.0+ formatting preferences including tab size,
     insert final newline, trim trailing whitespace, etc.
+
+- **`lsp_range_formatting`**: Format a specific range in a document using LSP
+  - Parameters: `connection_id` (string), `document` (DocumentIdentifier),
+    `lsp_client_name` (string), `start_line` (number), `start_character` (number),
+    `end_line` (number), `end_character` (number), `options` (FormattingOptions),
+    `apply_edits` (boolean, optional) (all positions are 0-indexed)
+  - Returns: Array of TextEdit objects or success confirmation if auto-applied
+  - Notes: Formats only the specified range with LSP 3.15.0+ formatting preferences
 
 ### Universal Document Identifier
 

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -4,7 +4,7 @@
 
 ### Tools
 
-The server provides 21 MCP tools for interacting with Neovim instances:
+The server provides 22 MCP tools for interacting with Neovim instances:
 
 #### Connection Management
 
@@ -207,12 +207,32 @@ All tools below require a `connection_id` parameter from connection establishmen
     - `document` (DocumentIdentifier): Universal document identifier
       (BufferId, ProjectRelativePath, or AbsolutePath)
     - `lsp_client_name` (string): LSP client name from lsp_clients
-    - `formatting_options` (FormattingOptions, optional): LSP formatting preferences
-    - `auto_apply` (boolean, optional): Whether to automatically apply formatting
+    - `options` (FormattingOptions): LSP formatting preferences
+    - `apply_edits` (boolean, optional): Whether to automatically apply formatting
       changes (default: false)
   - **Returns**: Array of TextEdit objects or success confirmation if auto-applied
   - **Usage**: Format documents using LSP with support for LSP 3.15.0+ formatting
     preferences including tab size, insert final newline, trim trailing whitespace
+
+- **`lsp_range_formatting`**: Format a specific range in a document using LSP
+  - **Parameters**:
+    - `connection_id` (string): Target Neovim instance ID
+    - `document` (DocumentIdentifier): Universal document identifier
+      (BufferId, ProjectRelativePath, or AbsolutePath)
+    - `lsp_client_name` (string): LSP client name from lsp_clients
+    - `start_line` (number): Range start position, line number starts from 0
+    - `start_character` (number): Range start position, character number starts
+      from 0
+    - `end_line` (number): Range end position, line number starts from 0
+    - `end_character` (number): Range end position, character number starts
+      from 0
+    - `options` (FormattingOptions): LSP formatting preferences
+    - `apply_edits` (boolean, optional): Whether to automatically apply formatting
+      changes (default: false)
+  - **Returns**: Array of TextEdit objects or success confirmation if auto-applied
+  - **Usage**: Format a specific range in documents using LSP with support for
+    LSP 3.15.0+ formatting preferences including tab size, insert final newline,
+    trim trailing whitespace
 
 ### Resources
 
@@ -234,7 +254,8 @@ This system enables LSP operations on files that may not be open in Neovim buffe
 providing enhanced flexibility for code analysis and navigation. The universal LSP
 tools (`lsp_code_actions`, `lsp_hover`, `lsp_document_symbols`,
 `lsp_references`, `lsp_definition`, `lsp_type_definition`,
-`lsp_implementations`, `lsp_declaration`, `lsp_rename`, `lsp_formatting`) accept
+`lsp_implementations`, `lsp_declaration`, `lsp_rename`, `lsp_formatting`,
+`lsp_range_formatting`) accept
 any of these
 document identifier types.
 

--- a/flake.nix
+++ b/flake.nix
@@ -65,10 +65,15 @@
               # Integration tests
               neovim-unwrapped
               lua-language-server
+
               go
               gopls
+
               zig
               zls
+
+              typescript
+              typescript-language-server
             ];
             shellHook = ''
               # Unset SOURCE_DATE_EPOCH to prevent reproducible build timestamps during development.

--- a/src/neovim/lua/lsp_range_formatting.lua
+++ b/src/neovim/lua/lsp_range_formatting.lua
@@ -1,0 +1,27 @@
+local clients = vim.lsp.get_clients()
+local client_name, params_raw, timeout_ms = unpack({ ... })
+local client
+for _, v in ipairs(clients) do
+    if v.name == client_name then
+        client = v
+    end
+end
+if client == nil then
+    return vim.json.encode({
+        err_msg = string.format("LSP client %s not found", vim.json.encode(client_name)),
+    })
+end
+
+local params = vim.json.decode(params_raw)
+local result, err = client:request_sync("textDocument/rangeFormatting", params, timeout_ms)
+if err then
+    return vim.json.encode({
+        err_msg = string.format(
+            "LSP client %s request_sync error: %s",
+            vim.json.encode(client_name),
+            vim.json.encode(err)
+        ),
+    })
+end
+
+return vim.json.encode(result)

--- a/src/neovim/testdata/cfg_lsp.lua
+++ b/src/neovim/testdata/cfg_lsp.lua
@@ -25,3 +25,10 @@ vim.lsp.config["zls"] = {
     root_markers = { ".root" },
 }
 vim.lsp.enable("zls")
+
+vim.lsp.config["ts_ls"] = {
+    cmd = { "typescript-language-server", "--stdio" },
+    filetypes = { "typescript", "typescriptreact", "typescript.tsx" },
+    root_markers = { ".root" },
+}
+vim.lsp.enable("ts_ls")


### PR DESCRIPTION
## Summary

- Add `lsp_range_formatting` tool for formatting specific ranges in documents using LSP
- Update all documentation to reflect the new tool (22 tools total)
- Support LSP 3.15.0+ formatting preferences with optional edit application

## Features

- **Range-specific formatting**: Format only selected ranges rather than entire documents
- **Universal document identification**: Support buffer IDs, project paths, and absolute paths
- **LSP 3.15.0+ compatibility**: Full support for modern formatting options
- **Optional edit application**: Choose whether to apply edits automatically or return them

## Documentation Updates

- Updated README.md with new tool documentation
- Updated CLAUDE.md with tool count and capabilities  
- Updated docs/instructions.md with detailed parameter documentation
- Updated CHANGELOG.md with new features section