### PR TITLE
Relax Diagnostic JSON schema

### DIFF
--- a/src/neovim/client.rs
+++ b/src/neovim/client.rs
@@ -226,7 +226,7 @@ where
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct Diagnostic {
     pub message: String,
-    pub code: Option<String>,
+    pub code: Option<serde_json::Value>,
     pub severity: u8,
     pub lnum: u64,
     pub col: u64,
@@ -247,7 +247,7 @@ pub struct UserData {
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct LSPDiagnostic {
-    pub code: Option<String>,
+    pub code: Option<serde_json::Value>,
     pub message: String,
     pub range: Range,
     pub severity: u8,


### PR DESCRIPTION
Accept `code` as number as well as as string.

Had this error coming up:

    Failed to parse diagnostics: invalid type: integer `0`, expected a string at line 1 column 261

from
```json
[
  {
    "message": "Missing property \"image\".",
    "lnum": 18,
    "bufnr": 16,
    "user_data": {
      "lsp": {
        "source": "yaml-schema: GitHub Workflow",
        "message": "Missing property \"image\".",
        "severity": 1,
        "range": {
          "start": {
            "character": 4,
            "line": 18
          },
          "end": {
            "character": 13,
            "line": 18
          }
        },
        "code": 0,
        "data": {
          "schemaUri": [
            "https://www.schemastore.org/github-workflow.json"
          ]
        }
      }
    },
    "source": "yaml-schema: GitHub Workflow",
    "end_lnum": 18,
    "namespace": 98,
    "col": 4,
    "code": 0,
    "end_col": 13,
    "severity": 1
  }
]
```