### PR TITLE
Add HTTP server transport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### New Features
+
+- **HTTP Server Transport**: Added HTTP server mode for web-based integrations
+  with streamable HTTP transport support
+- **Multi-Transport Support**: Server now supports both stdio (default) and
+  HTTP server transport modes for different integration scenarios
+
+### New CLI Options
+
+- `--http-port <PORT>` - Enable HTTP server mode on the specified port
+- `--http-host <HOST>` - HTTP server bind address (defaults to 127.0.0.1)
+
+### Dependencies
+
+- Added `hyper` for high-performance HTTP server transport
+- Added `hyper-util` for HTTP utilities with server and service features
+- Added `tower-http` for HTTP middleware and CORS support
+- Updated `rmcp` to include streamable HTTP server transport features
+
 ## [v0.4.0] - 2025-08-16
 
 ### New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,10 @@ This is a Rust-based Model Context Protocol (MCP) server that provides AI
 assistants with programmatic access to Neovim instances. The server supports
 both Unix socket/named pipe and TCP connections, implements 23 core MCP
 tools for Neovim interaction, and provides diagnostic resources through the
-`nvim-diagnostics://` URI scheme. The project uses Rust 2024 edition and
-focuses on async/concurrent operations with proper error handling throughout.
+`nvim-diagnostics://` URI scheme. The server now supports multiple transport
+modes: stdio (default), and HTTP server for web-based integrations.
+The project uses Rust 2024 edition and focuses on async/concurrent operations
+with proper error handling throughout.
 
 ## Development Commands
 
@@ -23,6 +25,12 @@ cargo run
 
 # With custom logging options
 cargo run -- --log-file ./nvim-mcp.log --log-level debug
+
+# HTTP server mode
+cargo run -- --http-port 8080
+
+# HTTP server mode with custom bind address
+cargo run -- --http-port 8080 --http-host 0.0.0.0
 
 # Production build and run
 cargo build --release
@@ -37,6 +45,8 @@ nix develop .
 - `--log-file <PATH>`: Log file path (defaults to stderr)
 - `--log-level <LEVEL>`: Log level (trace, debug, info, warn, error;
   defaults to info)
+- `--http-port <PORT>`: Enable HTTP server mode on the specified port
+- `--http-host <HOST>`: HTTP server bind address (defaults to 127.0.0.1)
 
 ### Testing
 
@@ -115,7 +125,7 @@ This modular architecture provides several advantages:
 
 ### Data Flow
 
-1. **MCP Communication**: stdio transport ↔ MCP client ↔ `NeovimMcpServer`
+1. **MCP Communication**: stdio/HTTP transport ↔ MCP client ↔ `NeovimMcpServer`
 2. **Neovim Integration**: `NeovimMcpServer` → `NeovimClientTrait` → `nvim-rs` →
    TCP/Unix socket → Neovim instance
 3. **Tool Execution**: MCP tool request → async Neovim API call → response
@@ -245,7 +255,8 @@ BLAKE3 hashes of the target string for consistent identification.
 
 ## Key Dependencies
 
-- **`rmcp`**: MCP protocol implementation with stdio transport and client features
+- **`rmcp`**: MCP protocol implementation with stdio transport, streamable
+  HTTP server transport, and client features
 - **`nvim-rs`**: Neovim msgpack-rpc client (with tokio feature)
 - **`tokio`**: Async runtime for concurrent operations (full feature set)
 - **`tracing`**: Structured logging with subscriber and appender support
@@ -257,6 +268,12 @@ BLAKE3 hashes of the target string for consistent identification.
 - **`dashmap`**: Lock-free concurrent HashMap for connection storage
 - **`regex`**: Pattern matching for connection-scoped resource URI parsing
 - **`blake3`**: Fast, deterministic hashing for connection ID generation
+
+**HTTP Server Transport Dependencies:**
+
+- **`hyper`**: High-performance HTTP library for HTTP server transport
+- **`hyper-util`**: Utilities for hyper with server and service features
+- **`tower-http`**: HTTP middleware and utilities with CORS support
 
 **Testing and Development Dependencies:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,14 +105,20 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -143,9 +149,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "blake3"
@@ -190,9 +196,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "shlex",
 ]
@@ -299,9 +305,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2"
+checksum = "08440b3dd222c3d0433e63e097463969485f112baff337dfdaca043a0d760570"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -309,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6"
+checksum = "d25b7912bc28a04ab1b7715a68ea03aaa15662b43a1a4b2c480531fd19f8bf7e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -323,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
+checksum = "ce154b9bea7fb0c8e8326e62d00354000c36e79770ff21b8c84e3aa267d9d531"
 dependencies = [
  "darling_core",
  "quote",
@@ -511,6 +517,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.10.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +552,80 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes 1.10.1",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes 1.10.1",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes 1.10.1",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "bytes 1.10.1",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httpdate",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+dependencies = [
+ "bytes 1.10.1",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -727,6 +826,8 @@ dependencies = [
  "dashmap",
  "futures 0.3.31",
  "glob",
+ "hyper",
+ "hyper-util",
  "nvim-rs",
  "rand",
  "regex",
@@ -736,8 +837,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.14",
+ "thiserror 2.0.15",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -844,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -989,20 +1091,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2faf35b7d3c4b7f8c21c45bb014011b32a0ce6444bf6094da04daab01a8c3c34"
 dependencies = [
  "base64",
+ "bytes 1.10.1",
  "chrono",
  "futures 0.3.31",
+ "http",
+ "http-body",
+ "http-body-util",
  "paste",
  "pin-project-lite",
  "process-wrap",
+ "rand",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.14",
+ "sse-stream",
+ "thiserror 2.0.15",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1135,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1192,6 +1302,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes 1.10.1",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,9 +1322,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1232,11 +1355,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
+checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
 dependencies = [
- "thiserror-impl 2.0.14",
+ "thiserror-impl 2.0.15",
 ]
 
 [[package]]
@@ -1252,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1369,6 +1492,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes 1.10.1",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1622,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,17 @@ clap = { version = "4.5", features = ["derive"] }
 rmcp = { version = "0.5.0", features = [
   "transport-io",
   "transport-child-process",
+  "transport-streamable-http-server",
+  "transport-worker",
   "client",
+] }
+tower-http = { version = "0.6", features = ["cors"] }
+hyper = { version = "1" }
+hyper-util = { version = "0", features = [
+  "server",
+  "service",
+  "tokio",
+  "http2",
 ] }
 
 # Neovim Integration

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A Model Context Protocol (MCP) server that provides seamless integration with
 Neovim instances, enabling AI assistants to interact with your editor through
 connections and access diagnostic information via structured resources.
+Supports both stdio and HTTP server transport modes for different integration
+scenarios.
 
 ## Features
 
@@ -18,6 +20,8 @@ connections and access diagnostic information via structured resources.
 - **Plugin Integration**: Automatic setup through Neovim plugin
 - **Modular Architecture**: Clean separation between core infrastructure,
   MCP tools, and resource handlers
+- **Multi-Transport Support**: Supports both stdio (default) and HTTP server
+  transport modes for web-based integrations
 
 ## Installation
 
@@ -47,8 +51,15 @@ cargo install --path .
 ```bash
 # Start as stdio MCP server (default)
 nvim-mcp
+
 # With custom logging
 nvim-mcp --log-file ./nvim-mcp.log --log-level debug
+
+# HTTP server mode
+nvim-mcp --http-port 8080
+
+# HTTP server mode with custom bind address
+nvim-mcp --http-port 8080 --http-host 0.0.0.0
 ```
 
 #### Command Line Options
@@ -56,6 +67,8 @@ nvim-mcp --log-file ./nvim-mcp.log --log-level debug
 - `--log-file <PATH>`: Path to log file (defaults to stderr)
 - `--log-level <LEVEL>`: Log level (trace, debug, info, warn, error;
   defaults to info)
+- `--http-port <PORT>`: Enable HTTP server mode on the specified port
+- `--http-host <HOST>`: HTTP server bind address (defaults to 127.0.0.1)
 
 ### 2. Setup Neovim Integration
 
@@ -118,6 +131,45 @@ Once both the MCP server and Neovim are running, here's a typical workflow:
    - Use `connect_tcp` tool with address like "127.0.0.1:6666"
    - Save the returned `connection_id`
 2. **Follow steps 3-4 above** with your connection ID
+
+## HTTP Server Transport
+
+The server supports HTTP transport mode for web-based integrations and
+applications that cannot use stdio transport. This is useful for web
+applications, browser extensions, or other HTTP-based MCP clients.
+
+### Starting HTTP Server Mode
+
+```bash
+# Start HTTP server on default localhost:8080
+nvim-mcp --http-port 8080
+
+# Bind to all interfaces
+nvim-mcp --http-port 8080 --http-host 0.0.0.0
+
+# With custom logging
+nvim-mcp --http-port 8080 --log-file ./nvim-mcp.log --log-level debug
+```
+
+### HTTP Transport Features
+
+- **Streamable HTTP**: Uses streamable HTTP server transport for real-time communication
+- **Stateful Mode**: Maintains session state across HTTP requests
+- **CORS Support**: Includes CORS middleware for cross-origin requests
+- **Concurrent Sessions**: Supports multiple concurrent HTTP client sessions
+
+### HTTP Client Integration
+
+When using HTTP transport, MCP clients should connect to the HTTP endpoint
+instead of stdio. The exact integration depends on your MCP client library,
+but generally involves:
+
+1. Configure client to use HTTP transport instead of stdio
+2. Point to the server URL (e.g., `http://localhost:8080`)
+3. Use the same MCP tools and resources as with stdio transport
+
+The HTTP transport maintains full compatibility with all existing MCP tools
+and resources - only the transport layer changes.
 
 ## Available Tools
 
@@ -434,6 +486,9 @@ cargo run --release
 
 # Build and run with custom logging
 cargo run -- --log-file ./debug.log --log-level debug
+
+# Build and run with HTTP server mode
+cargo run -- --http-port 8080
 
 # Using Nix
 nix run .

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,9 +124,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             let service = service.clone();
             tokio::spawn(async move {
-                let _result = Builder::new(TokioExecutor::default())
+                if let Err(e) = Builder::new(TokioExecutor::default())
                     .serve_connection(io, service)
-                    .await;
+                    .await
+                {
+                    error!("Error serving HTTP connection: {e}");
+                }
             });
         }
     } else {


### PR DESCRIPTION
Implement streamable HTTP server transport alongside existing stdio transport. Add CLI options for HTTP mode with configurable port and bind address. Include required dependencies: hyper, hyper-util, tower-http for HTTP handling.

- Add --http-port and --http-host CLI options
- Support both stdio and HTTP server modes
- Use rmcp streamable HTTP transport with local session management
- Enable CORS support via tower-http
- Maintain backward compatibility with stdio mode as default