### PR TITLE
Add test coverage reporting with codecov integration

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,5 +57,12 @@ jobs:
       - name: Run nix flake check
         run: nix flake check --all-systems
 
-      - name: Run integration tests
-        run: cargo test -- --show-output
+      - name: Run integration tests with coverage
+        run: nix run .#cov -- --out xml -- --show-output
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v5
+        with:
+          file: ./cobertura.xml
+          token: ${{secrets.CODECOV_TOKEN}}
+          fail_ci_if_error: github.actor != 'dependabot[bot]'

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             packages = with pkgs; [
               # Development
               rust-analyzer-nightly
+              cargo-tarpaulin
               pre-commit
 
               # Integration tests
@@ -119,6 +120,17 @@
               description = "MCP server for Neovim";
             };
             program = lib.getExe self.packages.${system}.nvim-mcp;
+          };
+          cov = {
+            type = "app";
+            meta = {
+              description = "Run tests with coverage";
+            };
+            program = lib.getExe (pkgs.writeShellScriptBin "test-coverage" ''
+              export CARGO_TARGET_DIR="$PWD/target/coverage"
+              rm -rf $CARGO_TARGET_DIR/tarpaulin/profraws
+              cargo tarpaulin --skip-clean "$@"
+            '');
           };
         };
       }


### PR DESCRIPTION
- Add cargo-tarpaulin to development dependencies in flake.nix
- Add 'cov' app for running tests with coverage using tarpaulin
- Update CI workflow to run tests with coverage and upload to codecov.io
- Modify integration tests to support tarpaulin compilation flags
- Handle CARGO_TARGET_DIR environment variable for coverage builds
- Add proper RUSTFLAGS extraction from tarpaulin for coverage compilation