### PR TITLE
Fix FormattingOptions deserialization to support string and struct formats

### DIFF
--- a/src/neovim/client.rs
+++ b/src/neovim/client.rs
@@ -788,6 +788,8 @@ pub struct FormattingOptions {
     pub extras: HashMap<String, serde_json::Value>,
 }
 
+impl_fromstr_serde_json!(FormattingOptions);
+
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct Command {
     /// Title of the command, like `save`.

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -318,6 +318,7 @@ pub struct DocumentRangeFormattingParams {
     /// Range end position, character number starts from 0
     pub end_character: u64,
     /// The formatting options
+    #[serde(deserialize_with = "string_or_struct")]
     pub options: FormattingOptions,
     /// Whether to apply the text edits automatically (default: false)
     #[serde(default)]


### PR DESCRIPTION
## Summary

- Enhanced FormattingOptions deserialization to support both string and struct formats
- Added impl_fromstr_serde_json! macro implementation for FormattingOptions 
- Updated DocumentRangeFormattingParams to use string_or_struct deserializer for options field

This fix resolves deserialization issues when LSP clients send formatting options in different formats, improving compatibility and robustness of the formatting functionality.