### PR TITLE
Add cursor_position tool for getting current cursor location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- **Cursor Position Tool**: Added `cursor_position` tool to get current cursor
+  position with buffer name and zero-based row/col coordinates
 - **LSP Readiness Tool**: Added `wait_for_lsp_ready` tool for ensuring LSP client
   readiness before performing operations, improving reliability of LSP workflows
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ with code in this repository.
 
 This is a Rust-based Model Context Protocol (MCP) server that provides AI
 assistants with programmatic access to Neovim instances. The server supports
-both Unix socket/named pipe and TCP connections, implements 23 core MCP
+both Unix socket/named pipe and TCP connections, implements 25 core MCP
 tools for Neovim interaction, and provides diagnostic resources through the
 `nvim-diagnostics://` URI scheme. The server now supports multiple transport
 modes: stdio (default), and HTTP server for web-based integrations.
@@ -222,7 +222,7 @@ This modular architecture provides several advantages:
 
 ### Available MCP Tools
 
-The server provides these 24 tools (implemented with `#[tool]` attribute):
+The server provides these 25 tools (implemented with `#[tool]` attribute):
 
 **Connection Management:**
 
@@ -237,30 +237,32 @@ The server provides these 24 tools (implemented with `#[tool]` attribute):
 1. **`list_buffers`**: List all open buffers for specific connection
 2. **`exec_lua`**: Execute arbitrary Lua code in specific Neovim instance
 3. **`wait_for_lsp_ready`**: Wait for LSP client to be ready and attached with timeout
-4. **`buffer_diagnostics`**: Get diagnostics for specific buffer on specific connection
-5. **`lsp_clients`**: Get workspace LSP clients for specific connection
-6. **`lsp_workspace_symbols`**: Search workspace symbols by query on specific
+4. **`cursor_position`**: Get the current cursor position: buffer name,
+  and zero-based row/col index
+5. **`buffer_diagnostics`**: Get diagnostics for specific buffer on specific connection
+6. **`lsp_clients`**: Get workspace LSP clients for specific connection
+7. **`lsp_workspace_symbols`**: Search workspace symbols by query on specific
    connection
-7. **`lsp_code_actions`**: Get LSP code actions with universal document
+8. **`lsp_code_actions`**: Get LSP code actions with universal document
    identification (supports buffer IDs, project-relative paths, and absolute paths)
-8. **`lsp_hover`**: Get LSP hover information with universal document
+9. **`lsp_hover`**: Get LSP hover information with universal document
    identification (supports buffer IDs, project-relative paths, and absolute paths)
-9. **`lsp_document_symbols`**: Get document symbols with universal document
+10. **`lsp_document_symbols`**: Get document symbols with universal document
    identification (supports buffer IDs, project-relative paths, and absolute paths)
-10. **`lsp_references`**: Get LSP references with universal document
+11. **`lsp_references`**: Get LSP references with universal document
    identification (supports buffer IDs, project-relative paths, and absolute paths)
-11. **`lsp_resolve_code_action`**: Resolve code actions that may have
+12. **`lsp_resolve_code_action`**: Resolve code actions that may have
     incomplete data
-12. **`lsp_apply_edit`**: Apply workspace edits using Neovim's LSP utility
+13. **`lsp_apply_edit`**: Apply workspace edits using Neovim's LSP utility
     functions
-13. **`lsp_definition`**: Get LSP definition with universal document identification
-14. **`lsp_type_definition`**: Get LSP type definition with universal document identification
-15. **`lsp_implementations`**: Get LSP implementations with universal document identification
-16. **`lsp_declaration`**: Get LSP declaration with universal document identification
-17. **`lsp_rename`**: Rename symbol across workspace using LSP
-18. **`lsp_formatting`**: Format document using LSP with optional auto-apply
-19. **`lsp_range_formatting`**: Format a specific range in a document using LSP
-20. **`lsp_organize_imports`**: Sort and organize imports using LSP with
+14. **`lsp_definition`**: Get LSP definition with universal document identification
+15. **`lsp_type_definition`**: Get LSP type definition with universal document identification
+16. **`lsp_implementations`**: Get LSP implementations with universal document identification
+17. **`lsp_declaration`**: Get LSP declaration with universal document identification
+18. **`lsp_rename`**: Rename symbol across workspace using LSP
+19. **`lsp_formatting`**: Format document using LSP with optional auto-apply
+20. **`lsp_range_formatting`**: Format a specific range in a document using LSP
+21. **`lsp_organize_imports`**: Sort and organize imports using LSP with
     auto-apply by default
 
 ### Universal Document Identifier System

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ scenarios.
 - **Buffer Operations**: List and inspect all open buffers with detailed information
 - **Diagnostics Access**: Retrieve diagnostics for buffers with error/warning details
 - **LSP Integration**: Access code actions and LSP client information
+- **Cursor Positioning**: Get current cursor position with buffer name and
+  zero-based coordinates
 - **MCP Resources**: Structured diagnostic data via connection-aware URI schemes
 - **Lua Execution**: Execute arbitrary Lua code directly in Neovim
 - **Plugin Integration**: Automatic setup through Neovim plugin

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -123,6 +123,14 @@ established automatically:
 5. Navigate to symbol locations using returned position information
 6. Keep connection active for continued navigation
 
+#### Cursor Position Workflow
+
+1. Connect to Neovim instance (cache connection_id)
+2. Use cursor_position tool to get current cursor location with zero-based coordinates
+3. Retrieve buffer name and row/col position for navigation or context understanding
+4. Use position information for targeted operations like hover, references, or definitions
+5. Keep connection active for continued cursor-based operations
+
 #### Multi-Instance Management
 
 1. Use get_targets to find all available instances

--- a/src/server/hybrid_router.rs
+++ b/src/server/hybrid_router.rs
@@ -220,7 +220,7 @@ impl HybridToolRouter {
         // Overwrite description for static tools if it has more comprehensive description
         tools.extend(self.static_router.list_all().into_iter().map(|mut tool| {
             if let Some(desc) = self.static_tool_descriptions.get(tool.name.as_ref()) {
-                tool.description = Some(desc.to_owned().into());
+                tool.description = Some(desc.to_owned().trim().into());
             }
             tool
         }));

--- a/src/server/lua/cursor_position.lua
+++ b/src/server/lua/cursor_position.lua
@@ -1,0 +1,5 @@
+local bufname = vim.api.nvim_buf_get_name(0)
+local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+-- row is one-indexed
+-- col is zero-indexed
+return { bufname = bufname, row = row - 1, col = col }

--- a/src/server/lua_tools.rs
+++ b/src/server/lua_tools.rs
@@ -242,7 +242,9 @@ pub async fn discover_lua_tools(
 }
 
 // Helper function to convert nvim_rs::Value to serde_json::Value
-fn convert_nvim_value_to_json(nvim_value: rmpv::Value) -> Result<serde_json::Value, NeovimError> {
+pub fn convert_nvim_value_to_json(
+    nvim_value: rmpv::Value,
+) -> Result<serde_json::Value, NeovimError> {
     match nvim_value {
         rmpv::Value::Nil => Ok(serde_json::Value::Null),
         rmpv::Value::Boolean(b) => Ok(serde_json::Value::Bool(b)),


### PR DESCRIPTION
## Summary

- Add new `cursor_position` MCP tool that returns the current cursor position with buffer name and zero-based row/col coordinates
- Include comprehensive integration tests for the new tool
- Update documentation across CHANGELOG.md, README.md, CLAUDE.md, and instructions.md to reflect the new tool
- Fix minor formatting issue in hybrid router static tool descriptions

## Changes

**New Tool Implementation:**
- Added `cursor_position` tool in `src/server/tools.rs` with connection-aware design
- Created Lua script `src/server/lua/cursor_position.lua` for cursor position retrieval
- Made `convert_nvim_value_to_json` function public in `lua_tools.rs` for reuse

**Testing:**
- Added comprehensive integration test `test_cursor_position_tool` covering both error cases and successful execution
- Test verifies proper JSON response format with required fields (bufname, row, col)
- Validates zero-based coordinate system

**Documentation Updates:**
- Updated tool count from 24 to 25 tools across documentation
- Added cursor position workflow section in instructions
- Updated feature lists in README and CHANGELOG
- Added detailed cursor position tool description

**Minor Improvements:**
- Fixed whitespace trimming in hybrid router static tool descriptions

The tool provides zero-based coordinates (row and col) for consistency with LSP and editor conventions, making it useful for programmatic cursor positioning and context-aware operations.