### PR TITLE
Fix Lua tool discovery for empty tool registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to this project will be documented in this file.
 - **Dynamic Tools Plugin Dependency** (#62): Added plugin availability check before
   Lua tool discovery to prevent errors when nvim-mcp plugin is not installed.
   Server now gracefully handles missing plugin and continues with static tools only
+- **Lua Tool Discovery for Empty Registries**: Fixed handling of cases where no
+  Lua tools are registered by returning null/empty map instead of failing. Added
+  fallback values for missing tool descriptions and input schemas to prevent
+  errors during tool registration
+- **Test Environment Isolation**: Added `-i NONE` flag to Neovim test instances
+  to disable shada file loading, ensuring consistent test behavior across different
+  environments and preventing interference from user's vim history and settings
 
 ### New Features
 

--- a/lua/nvim-mcp/init.lua
+++ b/lua/nvim-mcp/init.lua
@@ -111,11 +111,17 @@ function M.get_registered_tools()
     for tool_name, tool_config in pairs(M._tool_registry) do
         tools[tool_name] = {
             name = tool_name,
-            description = tool_config.description,
-            input_schema = tool_config.parameters,
+            description = tool_config.description or "",
+            input_schema = tool_config.parameters or {
+                type = "object",
+            },
         }
     end
-    return tools
+    if #tools == 0 then
+        return nil
+    else
+        return tools
+    end
 end
 
 -- Tool Execution API with error handling

--- a/lua/nvim-mcp/init.lua
+++ b/lua/nvim-mcp/init.lua
@@ -117,7 +117,7 @@ function M.get_registered_tools()
             },
         }
     end
-    if #tools == 0 then
+    if next(tools) == nil then
         return nil
     else
         return tools

--- a/src/server/integration_tests.rs
+++ b/src/server/integration_tests.rs
@@ -4,7 +4,7 @@ use rmcp::{
     model::{CallToolRequestParam, ReadResourceRequestParam},
     serde_json::{Map, Value},
     service::ServiceExt,
-    transport::TokioChildProcess,
+    transport::{ConfigureCommandExt, TokioChildProcess},
 };
 use tokio::process::Command;
 use tracing::{error, info};
@@ -43,7 +43,10 @@ fn get_target_dir() -> PathBuf {
 /// Macro to create an MCP service using the pre-compiled binary
 macro_rules! create_mcp_service {
     () => {{
-        let command = Command::new(get_compiled_binary());
+        let command = Command::new(get_compiled_binary()).configure(|cmd| {
+            // cmd.args(["--log-file", "."]);
+            cmd.args(["--connect", "manual"]);
+        });
         ().serve(TokioChildProcess::new(command)?)
             .await
             .map_err(|e| {

--- a/src/server/lua_tools.rs
+++ b/src/server/lua_tools.rs
@@ -220,25 +220,26 @@ pub async fn discover_lua_tools(
     let json_result = convert_nvim_value_to_json(result)?;
 
     // First deserialize into temporary struct without validator
-    let temp_tools: HashMap<String, LuaToolConfig> = serde_json::from_value(json_result)
+    let temp_tools: Option<HashMap<String, LuaToolConfig>> = serde_json::from_value(json_result)
         .map_err(|e| NeovimError::Api(format!("Failed to parse tool configs: {}", e)))?;
 
-    // Convert to proper LuaToolConfig with validators
-    let mut tools = HashMap::new();
-    for (key, mut tool) in temp_tools {
-        if let Err(e) = tool.init() {
-            let tool_name = tool.name();
-            tracing::warn!("Failed to create validator for tool '{}': {}", tool_name, e);
-            return Err(NeovimError::Api(format!(
-                "Failed to initialize tool '{}': {}",
-                tool_name, e
-            )));
+    if let Some(mut tools) = temp_tools {
+        debug!("Discovered {} Lua tools", tools.len());
+        for tool in tools.values_mut() {
+            if let Err(e) = tool.init() {
+                let tool_name = tool.name();
+                tracing::warn!("Failed to create validator for tool '{}': {}", tool_name, e);
+                return Err(NeovimError::Api(format!(
+                    "Failed to initialize tool '{}': {}",
+                    tool_name, e
+                )));
+            }
         }
-        tools.insert(key, tool);
+        Ok(tools)
+    } else {
+        debug!("No Lua tools discovered");
+        return Ok(HashMap::new());
     }
-
-    debug!("Discovered {} Lua tools", tools.len());
-    Ok(tools)
 }
 
 // Helper function to convert nvim_rs::Value to serde_json::Value

--- a/src/server/lua_tools.rs
+++ b/src/server/lua_tools.rs
@@ -4,7 +4,7 @@ use rmcp::{
     ErrorData as McpError,
     model::{CallToolResult, Content},
 };
-use tracing::{debug, instrument};
+use tracing::{debug, info, instrument, warn};
 
 use super::core::NeovimMcpServer;
 use super::hybrid_router::DynamicTool;
@@ -205,7 +205,7 @@ pub async fn discover_lua_tools(
     let plugin_available = check_plugin_availability(client).await?;
 
     if !plugin_available {
-        debug!("nvim-mcp Lua plugin is not installed, skipping dynamic tool discovery");
+        warn!("nvim-mcp Lua plugin is not installed, skipping dynamic tool discovery");
         return Ok(HashMap::new());
     }
 
@@ -224,7 +224,7 @@ pub async fn discover_lua_tools(
         .map_err(|e| NeovimError::Api(format!("Failed to parse tool configs: {}", e)))?;
 
     if let Some(mut tools) = temp_tools {
-        debug!("Discovered {} Lua tools", tools.len());
+        info!("Discovered {} Lua tools", tools.len());
         for tool in tools.values_mut() {
             if let Err(e) = tool.init() {
                 let tool_name = tool.name();
@@ -237,7 +237,7 @@ pub async fn discover_lua_tools(
         }
         Ok(tools)
     } else {
-        debug!("No Lua tools discovered");
+        info!("No Lua tools discovered");
         return Ok(HashMap::new());
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -171,7 +171,16 @@ pub async fn setup_neovim_instance_advance(
     let listen = format!("{HOST}:{port}");
 
     let mut child = StdCommand::new(nvim_path())
-        .args(["-n", "-u", cfg_path, "--headless", "--listen", &listen])
+        .args([
+            "-n",
+            "-i",
+            "NONE",
+            "-u",
+            cfg_path,
+            "--headless",
+            "--listen",
+            &listen,
+        ])
         .args(
             (!open_file.is_empty())
                 .then_some(vec![open_file])
@@ -212,7 +221,16 @@ pub async fn setup_neovim_instance_socket_advance(
     open_file: &str,
 ) -> std::process::Child {
     let mut child = StdCommand::new(nvim_path())
-        .args(["-n", "-u", cfg_path, "--headless", "--listen", socket_path])
+        .args([
+            "-n",
+            "-i",
+            "NONE",
+            "-u",
+            cfg_path,
+            "--headless",
+            "--listen",
+            socket_path,
+        ])
         .args(
             (!open_file.is_empty())
                 .then_some(vec![open_file])
@@ -254,7 +272,16 @@ pub async fn setup_neovim_instance_pipe_advance(
     open_file: &str,
 ) -> std::process::Child {
     let mut child = StdCommand::new(nvim_path())
-        .args(&["-u", cfg_path, "--headless", "--listen", pipe_path])
+        .args(&[
+            "-n",
+            "-i",
+            "NONE",
+            "-u",
+            cfg_path,
+            "--headless",
+            "--listen",
+            pipe_path,
+        ])
         .args(
             (!open_file.is_empty())
                 .then_some(vec![open_file])
@@ -325,7 +352,16 @@ pub async fn setup_test_neovim_instance(
     ipc_path: &str,
 ) -> Result<NeovimIpcGuard, Box<dyn std::error::Error>> {
     let mut child = StdCommand::new(nvim_path())
-        .args(["-u", "NONE", "--headless", "--listen", ipc_path])
+        .args([
+            "-n",
+            "-i",
+            "NONE",
+            "-u",
+            "NONE",
+            "--headless",
+            "--listen",
+            ipc_path,
+        ])
         .spawn()
         .map_err(|e| {
             format!("Failed to start Neovim - ensure nvim is installed and in PATH: {e}")


### PR DESCRIPTION
## Summary

- Fix Lua tool discovery for empty tool registries by handling empty table return values
- Add improved Neovim startup flags to test utilities for better reliability

This PR addresses an issue where the Lua tool discovery would fail when the tool registry was empty, improving the robustness of the dynamic tool system.