### PR TITLE
Add comprehensive Lua type annotations and improve tool configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ All notable changes to this project will be documented in this file.
   with HTML, Cobertura, and Markdown report generation
 - **CI Coverage Integration**: Added codecov.io integration with automated
   coverage reporting in GitHub Actions
+- **Lua Plugin Type Annotations**: Added comprehensive type annotations for
+  `SetupOptions`, `CustomTool`, and `JSONSchema` classes to improve IDE support
+  and documentation clarity
 
 ## [v0.5.0] - 2025-08-20
 

--- a/src/testdata/cfg_lsp.lua
+++ b/src/testdata/cfg_lsp.lua
@@ -40,6 +40,13 @@ local M = require("nvim-mcp")
 local MCP = M.MCP
 M.setup({
     custom_tools = {
+        format = {
+            -- Do nothing actually. Test various of configuration options
+            description = "Run format on the current buffer.",
+            handler = function()
+                return MCP.success("success")
+            end,
+        },
         save_buffer = {
             description = "Save a specific buffer by ID",
             parameters = {


### PR DESCRIPTION
## Summary
- Added comprehensive Lua type annotations for nvim-mcp plugin using LuaLS annotation format
- Improved plugin configuration structure with proper type definitions
- Enhanced setup function with optional user configuration merging
- Updated CHANGELOG.md with new type annotations entry
- Better IDE support and type checking for Lua development

## Changes
- lua/nvim-mcp/init.lua: Complete type annotations for all functions and objects
- CHANGELOG.md: Added entry for type annotations improvement