### PR TITLE
Fix CD action failure by adding docs/tools/ directory to Cargo.toml include list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ include = [
   "/src",
   "/build.rs",
   "/docs/instructions.md",
+  "/docs/tools/",
   "/.packaged-commit",
   "/Cargo.toml",
   "/Cargo.lock",


### PR DESCRIPTION
## Summary

- Add docs/tools/ directory to Cargo.toml include list to fix package distribution
- Resolves CD action failure when publishing to crates.io due to missing documentation files

This change fixes the publishing error that occurred when the docs/tools/ directory was referenced but not properly included in the package manifest.