### PR TITLE
Add LSP call hierarchy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- **LSP Call Hierarchy Support**: Added comprehensive call hierarchy support
+  with three new LSP tools: `lsp_call_hierarchy_prepare`,
+  `lsp_call_hierarchy_incoming_calls`, and `lsp_call_hierarchy_outgoing_calls`.
+  These tools provide full call hierarchy navigation capabilities including
+  preparing call hierarchy items at specific positions, finding incoming
+  callers, and discovering outgoing calls with complete range information
 - **Dynamic Connection Status in Server Info**: Enhanced server information to
   include real-time connection status display showing current connection mode
   and active connections with their IDs and targets. This provides better

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-The server provides 26 MCP tools for interacting with Neovim:
+The server provides 29 MCP tools for interacting with Neovim:
 
 ## Connection Management
 
@@ -138,6 +138,30 @@ establishment phase:
   - Returns: Array of TextEdit objects or success confirmation if auto-applied
   - Notes: Organizes and sorts imports with auto-apply enabled by default
 
+- **`lsp_call_hierarchy_prepare`**: Prepare call hierarchy for a symbol at a
+  specific position
+  - Parameters: `connection_id` (string), `document` (DocumentIdentifier),
+    `lsp_client_name` (string), `line` (number), `character` (number)
+    (all positions are 0-indexed)
+  - Returns: Array of CallHierarchyItem objects or null if no call hierarchy
+    available
+  - Notes: First step in call hierarchy workflow; prepares symbol for
+    incoming/outgoing calls analysis
+
+- **`lsp_call_hierarchy_incoming_calls`**: Get incoming calls for a call
+  hierarchy item
+  - Parameters: `connection_id` (string), `lsp_client_name` (string),
+    `item` (CallHierarchyItem) - Call hierarchy item from prepare step
+  - Returns: Array of CallHierarchyIncomingCall objects showing callers
+  - Notes: Shows all locations where the symbol is called from
+
+- **`lsp_call_hierarchy_outgoing_calls`**: Get outgoing calls for a call
+  hierarchy item
+  - Parameters: `connection_id` (string), `lsp_client_name` (string),
+    `item` (CallHierarchyItem) - Call hierarchy item from prepare step
+  - Returns: Array of CallHierarchyOutgoingCall objects showing callees
+  - Notes: Shows all symbols called by the selected symbol
+
 ## Universal Document Identifier
 
 The `document` parameter in the universal LSP tools accepts a `DocumentIdentifier`
@@ -188,3 +212,27 @@ This enables AI assistants to perform complete code refactoring, quick fixes,
 and other LSP-powered transformations. The implementation uses Neovim's native
 `vim.lsp.util.apply_workspace_edit()` function with proper position encoding
 handling, ensuring reliable and accurate file modifications.
+
+## Complete LSP Call Hierarchy Workflow
+
+The server supports full LSP call hierarchy navigation:
+
+1. **Prepare Call Hierarchy**: Use `lsp_call_hierarchy_prepare` to get call
+   hierarchy items at a specific position
+2. **Get Incoming Calls**: Use `lsp_call_hierarchy_incoming_calls` to find all
+   locations that call the selected symbol
+3. **Get Outgoing Calls**: Use `lsp_call_hierarchy_outgoing_calls` to find all
+   symbols called by the selected symbol
+
+**Example Workflow**:
+
+```text
+1. lsp_call_hierarchy_prepare → Get CallHierarchyItem at symbol position
+2. lsp_call_hierarchy_incoming_calls → Find all callers of the symbol
+3. lsp_call_hierarchy_outgoing_calls → Find all symbols called by the symbol
+```
+
+This enables comprehensive call hierarchy analysis for understanding code
+relationships, dependency tracking, and navigation through function call chains.
+Supports languages with LSP servers that implement call hierarchy capabilities
+(LSP 3.16.0+).

--- a/src/neovim/lua/lsp_call_hierarchy_incoming_calls.lua
+++ b/src/neovim/lua/lsp_call_hierarchy_incoming_calls.lua
@@ -1,0 +1,27 @@
+local clients = vim.lsp.get_clients()
+local client_name, params_raw, timeout_ms = unpack({ ... })
+local client
+for _, v in ipairs(clients) do
+    if v.name == client_name then
+        client = v
+    end
+end
+if client == nil then
+    return vim.json.encode({
+        err_msg = string.format("LSP client %s not found", vim.json.encode(client_name)),
+    })
+end
+
+local params = vim.json.decode(params_raw)
+local result, err = client:request_sync("callHierarchy/incomingCalls", params, timeout_ms)
+if err then
+    return vim.json.encode({
+        err_msg = string.format(
+            "LSP client %s request_sync error: %s",
+            vim.json.encode(client_name),
+            vim.json.encode(err)
+        ),
+    })
+end
+
+return vim.json.encode(result)

--- a/src/neovim/lua/lsp_call_hierarchy_outgoing_calls.lua
+++ b/src/neovim/lua/lsp_call_hierarchy_outgoing_calls.lua
@@ -1,0 +1,27 @@
+local clients = vim.lsp.get_clients()
+local client_name, params_raw, timeout_ms = unpack({ ... })
+local client
+for _, v in ipairs(clients) do
+    if v.name == client_name then
+        client = v
+    end
+end
+if client == nil then
+    return vim.json.encode({
+        err_msg = string.format("LSP client %s not found", vim.json.encode(client_name)),
+    })
+end
+
+local params = vim.json.decode(params_raw)
+local result, err = client:request_sync("callHierarchy/outgoingCalls", params, timeout_ms)
+if err then
+    return vim.json.encode({
+        err_msg = string.format(
+            "LSP client %s request_sync error: %s",
+            vim.json.encode(client_name),
+            vim.json.encode(err)
+        ),
+    })
+end
+
+return vim.json.encode(result)

--- a/src/neovim/lua/lsp_call_hierarchy_prepare.lua
+++ b/src/neovim/lua/lsp_call_hierarchy_prepare.lua
@@ -1,0 +1,27 @@
+local clients = vim.lsp.get_clients()
+local client_name, params_raw, timeout_ms = unpack({ ... })
+local client
+for _, v in ipairs(clients) do
+    if v.name == client_name then
+        client = v
+    end
+end
+if client == nil then
+    return vim.json.encode({
+        err_msg = string.format("LSP client %s not found", vim.json.encode(client_name)),
+    })
+end
+
+local params = vim.json.decode(params_raw)
+local result, err = client:request_sync("textDocument/prepareCallHierarchy", params, timeout_ms)
+if err then
+    return vim.json.encode({
+        err_msg = string.format(
+            "LSP client %s request_sync error: %s",
+            vim.json.encode(client_name),
+            vim.json.encode(err)
+        ),
+    })
+end
+
+return vim.json.encode(result)

--- a/src/neovim/mod.rs
+++ b/src/neovim/mod.rs
@@ -6,8 +6,8 @@ mod error;
 pub mod integration_tests;
 
 pub use client::{
-    CodeAction, DocumentIdentifier, FormattingOptions, NeovimClient, NeovimClientTrait, Position,
-    PrepareRenameResult, Range, WorkspaceEdit, string_or_struct,
+    CallHierarchyItem, CodeAction, DocumentIdentifier, FormattingOptions, NeovimClient,
+    NeovimClientTrait, Position, PrepareRenameResult, Range, WorkspaceEdit, string_or_struct,
 };
 
 pub use error::NeovimError;


### PR DESCRIPTION
## Summary

- Add LSP call hierarchy support with prepare, incoming calls, and outgoing calls operations
- Update documentation for the new call hierarchy feature