### PR TITLE
Add comprehensive read tool with multiple document identifier support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- **Document Reading Tool**: Added new `read` tool for reading document content
+  with universal document identification support. The tool supports reading from
+  buffer IDs, project-relative paths, and absolute file paths with optional
+  line range specification (start/end parameters). This enables comprehensive
+  document content access for analysis and processing workflows
 - **LSP Call Hierarchy Support**: Added comprehensive call hierarchy support
   with three new LSP tools: `lsp_call_hierarchy_prepare`,
   `lsp_call_hierarchy_incoming_calls`, and `lsp_call_hierarchy_outgoing_calls`.

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -70,8 +70,9 @@ Cache the `connection_id` for all subsequent operations.
 2. Read `nvim-diagnostics://{connection_id}/workspace` resource for
    project-wide analysis
 3. Use `buffer_diagnostics` for file-specific investigation
-4. Group diagnostics by severity and file
-5. Keep connection active for follow-up analysis
+4. Use `read` tool with `DocumentIdentifier` for document content analysis
+5. Group diagnostics by severity and file
+6. Keep connection active for follow-up analysis
 
 ### Symbol Navigation
 
@@ -89,6 +90,7 @@ Cache the `connection_id` for all subsequent operations.
    - `lsp_references` for usage sites
    - `lsp_definition` for declarations
 3. Navigate to results using `navigate` tool
+4. Read document content at specific positions with `read` tool
 
 ## Resource Strategy
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-The server provides 32 MCP tools for interacting with Neovim:
+The server provides 33 MCP tools for interacting with Neovim:
 
 ## Connection Management
 
@@ -41,6 +41,15 @@ establishment phase:
 
 - **`list_buffers`**: List all open buffers with names and line counts
   - Parameters: `connection_id` (string) - Target Neovim connection
+
+- **`read`**: Read document content with universal document identification
+  - Parameters: `connection_id` (string), `document` (DocumentIdentifier),
+    `start` (number, optional, default: 0) - Start line index (0-based),
+    `end` (number, optional, default: -1) - End line index, exclusive
+    (0-based, -1 for end of buffer)
+  - Returns: Document content as text
+  - Notes: Supports reading from buffer IDs, project-relative paths, and
+    absolute file paths with optional line range specification
 
 - **`buffer_diagnostics`**: Get diagnostics for a specific buffer
   - Parameters: `connection_id` (string), `id` (number) - Buffer ID

--- a/docs/tools/read.md
+++ b/docs/tools/read.md
@@ -1,0 +1,28 @@
+Read document content with universal document identification
+
+Supports reading from:
+
+- Buffer IDs (for currently open files)
+- Project-relative paths (relative to project root)
+- Absolute file paths
+
+Parameters:
+
+- `connection_id`: Target Neovim connection
+- `document`: DocumentIdentifier specifying the target document
+- `start`: Start line index (0-based, optional, default: 0)
+- `end`: End line index, exclusive (0-based, optional, default: -1 for end of buffer)
+
+Examples:
+
+```json
+// Read entire buffer
+{"connection_id": "abc123", "document": {"buffer_id": 0}}
+
+// Read specific line range from project file
+{"connection_id": "abc123", "document": {"project_relative_path": "src/main.rs"},
+ "start": 5, "end": 15}
+
+// Read from absolute path
+{"connection_id": "abc123", "document": {"absolute_path": "/home/user/project/src/main.rs"}}
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,7 +109,8 @@ Neovim instances associated with your current project:
    - Reports connection status and IDs
 3. **Use connection-aware tools directly**:
    - Server logs will show the `connection_id`s for connected instances
-   - Use tools like `list_buffers`, `buffer_diagnostics`, etc. with these IDs
+   - Use tools like `list_buffers`, `buffer_diagnostics`, `read`, etc.
+     with these IDs
    - Access resources immediately without manual connection setup
 
 ### Specific Target Mode

--- a/src/neovim/lua/navigate.lua
+++ b/src/neovim/lua/navigate.lua
@@ -1,7 +1,4 @@
--- Navigate tool implementation
--- Args: uri, row, col, buffer_id
 local params_raw = ...
-
 local params = vim.json.decode(params_raw)
 
 -- Convert to 1-based row for Vim (col is already 0-based)
@@ -43,7 +40,6 @@ end
 
 -- Set the cursor position
 local current_buf = vim.api.nvim_get_current_buf()
-local line_count = vim.api.nvim_buf_line_count(current_buf)
 
 -- Set cursor position
 vim.api.nvim_win_set_cursor(0, { params.position.line, params.position.character })

--- a/src/neovim/lua/read_document.lua
+++ b/src/neovim/lua/read_document.lua
@@ -1,0 +1,23 @@
+local params_raw = ...
+local params = vim.json.decode(params_raw)
+
+local start_line = params.start_line
+local end_line = params.end_line
+
+if params.buffer_id ~= nil then
+    local lines = vim.api.nvim_buf_get_lines(params.buffer_id, start_line, end_line, false)
+    return vim.json.encode({ result = table.concat(lines, "\n") })
+else
+    local lines = vim.fn.readfile(params.file_path)
+    local result = {}
+
+    if end_line < 0 then
+        end_line = #lines + 1 + end_line
+    end
+
+    for i = start_line, math.min(end_line, #lines) do
+        result[#result + 1] = lines[i]
+    end
+
+    return vim.json.encode({ result = table.concat(result, "\n") })
+end

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -703,38 +703,7 @@ impl NeovimMcpServer {
         }): Parameters<BufferReadRequest>,
     ) -> Result<CallToolResult, McpError> {
         let client = self.get_connection(&connection_id)?;
-        let text_content = match &document {
-            DocumentIdentifier::BufferId(buffer_id) => {
-                let lua_code = format!(
-                    "return vim.api.nvim_buf_get_lines({}, {}, {}, false)",
-                    buffer_id, start, end
-                );
-                let result = client.execute_lua(&lua_code).await?;
-
-                // Convert nvim Value to lines and join them with newlines
-                let lines = lua_tools::convert_nvim_value_to_json(result).map_err(|e| {
-                    McpError::internal_error(
-                        format!("Failed to convert buffer lines result to JSON: {}", e),
-                        None,
-                    )
-                })?;
-
-                // Extract lines from the JSON array and join them
-                if let serde_json::Value::Array(line_array) = lines {
-                    line_array
-                        .into_iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                        .collect::<Vec<String>>()
-                        .join("\n")
-                } else {
-                    return Err(McpError::internal_error(
-                        "Expected array of lines from nvim_buf_get_lines".to_string(),
-                        None,
-                    ));
-                }
-            }
-            _ => unimplemented!(),
-        };
+        let text_content = client.read_document(document, start, end).await?;
         Ok(CallToolResult::success(vec![Content::text(text_content)]))
     }
 

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -484,6 +484,7 @@ impl NeovimMcpServer {
         include_files! {
             get_targets,
             connect,
+            read,
         }
     }
 }
@@ -691,7 +692,7 @@ impl NeovimMcpServer {
         )?]))
     }
 
-    #[tool(description = "Read content")]
+    #[tool]
     #[instrument(skip(self))]
     pub async fn read(
         &self,


### PR DESCRIPTION
## Summary
- Add new read tool that supports reading document content from Neovim buffers and files
- Support multiple document identifier formats: buffer_id, project_relative_path, and absolute_path  
- Include comprehensive line range support for partial document reading
- Add extensive integration tests covering all identifier formats and edge cases
- Enhance Neovim client with read_document method and Lua implementation

## Changes
- Implement read tool in server/tools.rs with flexible document identifier support
- Add read_document method to NeovimClientTrait with buffer ID and file path handling
- Create Lua script for reading from both buffers and files with line range support
- Add comprehensive integration tests for buffer reading, project relative paths, absolute paths, and invalid scenarios
- Support string or struct deserialization for better Claude Code compatibility

The read tool enables AI assistants to efficiently read document content from various sources within the Neovim environment, supporting both full document and partial line range access.