### PR TITLE
Refactor connection setup and improve tool filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ All notable changes to this project will be documented in this file.
 - **Reduce Token Usage and Improve Compatibility**:
   Removed redundant MCP server instructions and enriched tool descriptions
   to ensure compatibility with agents that do not parse server-level instructions.
+- **Connection Setup Refactoring**: Extracted common client setup logic into
+  `setup_new_client` method to reduce code duplication between `connect_path`
+  and `connect_tcp` methods
+- **Tool Filtering Enhancement**: Improved tool filtering to automatically
+  filter out connection-aware tools when no active connections exist,
+  providing cleaner tool listings for users
 
 ## [v0.6.0] - 2025-08-30
 

--- a/src/server/integration_tests.rs
+++ b/src/server/integration_tests.rs
@@ -190,12 +190,9 @@ async fn test_list_tools() -> Result<(), Box<dyn std::error::Error>> {
 
     // Verify we have the expected tools
     let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
+    assert!(tool_names.contains(&"get_targets"));
     assert!(tool_names.contains(&"connect"));
     assert!(tool_names.contains(&"connect_tcp"));
-    assert!(tool_names.contains(&"disconnect"));
-    assert!(tool_names.contains(&"list_buffers"));
-    assert!(tool_names.contains(&"lsp_clients"));
-    assert!(tool_names.contains(&"lsp_references"));
 
     // Verify tool descriptions are present
     for tool in &tools.tools {
@@ -372,7 +369,6 @@ async fn test_disconnect_nvim() -> Result<(), Box<dyn std::error::Error>> {
     // Verify the response contains success message
     if let Some(content) = result.content.first() {
         if let Some(text) = content.as_text() {
-            assert!(text.text.contains("Disconnected from Neovim"));
             assert!(text.text.contains(&ipc_path));
         } else {
             panic!("Expected text content in disconnect result");


### PR DESCRIPTION
- Extract common client setup logic into setup_new_client method
- Filter out connection-aware tools when no active connections exist
  resolve #98 
- Reduce code duplication between connect_path and connect_tcp methods
