### PR TITLE
Use well-formatted JSON output instead of debug.

### DIFF
--- a/src/neovim/client.rs
+++ b/src/neovim/client.rs
@@ -1556,10 +1556,10 @@ impl<T> From<NvimExecuteLuaResult<T>> for Result<T, NeovimError> {
 impl NeovimClient<Connection> {
     #[instrument(skip(self))]
     pub async fn connect_path(&mut self, path: &str) -> Result<(), NeovimError> {
-        if self.connection.is_some() {
+        if let Some(conn) = &self.connection {
             return Err(NeovimError::Connection(format!(
                 "Already connected to {}. Disconnect first.",
-                self.connection.as_ref().unwrap().target()
+                conn.target()
             )));
         }
 
@@ -1593,10 +1593,10 @@ impl NeovimClient<Connection> {
 impl NeovimClient<TcpStream> {
     #[instrument(skip(self))]
     pub async fn connect_tcp(&mut self, address: &str) -> Result<(), NeovimError> {
-        if self.connection.is_some() {
+        if let Some(conn) = &self.connection {
             return Err(NeovimError::Connection(format!(
                 "Already connected to {}. Disconnect first.",
-                self.connection.as_ref().unwrap().target()
+                conn.target()
             )));
         }
 

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -614,10 +614,14 @@ impl NeovimMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let client = self.get_connection(&connection_id)?;
         let result = client.execute_lua(&code).await?;
+        let json_result = lua_tools::convert_nvim_value_to_json(result).map_err(|e| {
+            McpError::internal_error(
+                format!("Failed to convert Lua result to JSON: {}", e),
+                None,
+            )
+        })?;
         Ok(CallToolResult::success(vec![Content::json(
-            serde_json::json!({
-                "result": format!("{:?}", result)
-            }),
+            serde_json::json!({ "result": json_result }),
         )?]))
     }
 

--- a/src/server/tools.rs
+++ b/src/server/tools.rs
@@ -615,10 +615,7 @@ impl NeovimMcpServer {
         let client = self.get_connection(&connection_id)?;
         let result = client.execute_lua(&code).await?;
         let json_result = lua_tools::convert_nvim_value_to_json(result).map_err(|e| {
-            McpError::internal_error(
-                format!("Failed to convert Lua result to JSON: {}", e),
-                None,
-            )
+            McpError::internal_error(format!("Failed to convert Lua result to JSON: {}", e), None)
         })?;
         Ok(CallToolResult::success(vec![Content::json(
             serde_json::json!({ "result": json_result }),


### PR DESCRIPTION
Replaced format!("{:?}", result) with convert_nvim_value_to_json() to produce clean JSON output instead of leaking Rust Debug representations like String(Utf8String { s: Ok("...") }) into MCP tool responses.