### PR TITLE
Fix rmcp 1.6 non_exhaustive compatibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // HTTP server mode
         let addr = format!("{}:{}", cli.http_host, port);
         info!("Starting HTTP server on {}", addr);
+        let mut http_config = StreamableHttpServerConfig::default();
+        http_config.stateful_mode = true;
         let service = TowerToHyperService::new(StreamableHttpService::new(
             move || {
                 Ok(NeovimMcpServer::with_connect_mode(Some(
@@ -211,10 +213,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 )))
             },
             LocalSessionManager::default().into(),
-            StreamableHttpServerConfig {
-                stateful_mode: true,
-                ..Default::default()
-            },
+            http_config,
         ));
         let listener = tokio::net::TcpListener::bind(addr).await?;
         loop {

--- a/src/server/hybrid_router.rs
+++ b/src/server/hybrid_router.rs
@@ -60,13 +60,7 @@ impl From<&dyn DynamicTool> for Tool {
             required.push(serde_json::json!("connection_id"));
         }
         let mut tool = Tool::new(val.name().to_owned(), val.description().to_owned(), schema);
-        tool.annotations = Some(ToolAnnotations {
-            title: Some(format!("Dynamic: {}", val.name())),
-            read_only_hint: None,
-            destructive_hint: None,
-            idempotent_hint: None,
-            open_world_hint: None,
-        });
+        tool.annotations = Some(ToolAnnotations::with_title(format!("Dynamic: {}", val.name())));
         tool
     }
 }
@@ -343,17 +337,12 @@ impl HybridToolRouter {
         debug!("Falling back to static tool: {}", tool_name);
 
         // Create ToolCallContext and delegate to static router
-        let request_param = CallToolRequestParams {
-            name: tool_name.to_string().into(),
-            arguments: Some(
-                arguments
-                    .as_object()
-                    .unwrap_or(&serde_json::Map::new())
-                    .clone(),
-            ),
-            meta: None,
-            task: None,
-        };
+        let request_param = CallToolRequestParams::new(tool_name.to_string()).with_arguments(
+            arguments
+                .as_object()
+                .unwrap_or(&serde_json::Map::new())
+                .clone(),
+        );
         let tool_context = ToolCallContext::new(server, request_param, _context);
         self.static_router.call(tool_context).await
     }

--- a/src/server/hybrid_router.rs
+++ b/src/server/hybrid_router.rs
@@ -60,7 +60,10 @@ impl From<&dyn DynamicTool> for Tool {
             required.push(serde_json::json!("connection_id"));
         }
         let mut tool = Tool::new(val.name().to_owned(), val.description().to_owned(), schema);
-        tool.annotations = Some(ToolAnnotations::with_title(format!("Dynamic: {}", val.name())));
+        tool.annotations = Some(ToolAnnotations::with_title(format!(
+            "Dynamic: {}",
+            val.name()
+        )));
         tool
     }
 }

--- a/src/server/integration_tests.rs
+++ b/src/server/integration_tests.rs
@@ -16,21 +16,18 @@ fn call_tool_req(
     name: impl Into<String>,
     arguments: Option<Map<String, Value>>,
 ) -> CallToolRequestParams {
-    CallToolRequestParams {
-        name: name.into().into(),
-        arguments,
-        meta: None,
-        task: None,
+    let req = CallToolRequestParams::new(name.into());
+    if let Some(arguments) = arguments {
+        req.with_arguments(arguments)
+    } else {
+        req
     }
 }
 
 /// Helper function to create ReadResourceRequestParams with only required fields.
 /// Other fields use default values to avoid API breakage when rmcp adds new fields.
 fn read_resource_req(uri: impl Into<String>) -> ReadResourceRequestParams {
-    ReadResourceRequestParams {
-        uri: uri.into(),
-        meta: None,
-    }
+    ReadResourceRequestParams::new(uri.into())
 }
 
 // Macro to create an MCP service using the pre-compiled binary

--- a/src/server/resources.rs
+++ b/src/server/resources.rs
@@ -112,14 +112,14 @@ impl ServerHandler for NeovimMcpServer {
                     .collect();
 
                 Ok(ReadResourceResult::new(vec![ResourceContents::text(
-                        serde_json::to_string_pretty(&connections).map_err(|e| {
-                            McpError::internal_error(
-                                "Failed to serialize connections",
-                                Some(json!({"error": e.to_string()})),
-                            )
-                        })?,
-                        uri,
-                    )]))
+                    serde_json::to_string_pretty(&connections).map_err(|e| {
+                        McpError::internal_error(
+                            "Failed to serialize connections",
+                            Some(json!({"error": e.to_string()})),
+                        )
+                    })?,
+                    uri,
+                )]))
             }
             "nvim-tools://" => {
                 // Overview of all tools and their connection mappings
@@ -163,14 +163,14 @@ impl ServerHandler for NeovimMcpServer {
                 });
 
                 Ok(ReadResourceResult::new(vec![ResourceContents::text(
-                        serde_json::to_string_pretty(&overview).map_err(|e| {
-                            McpError::internal_error(
-                                "Failed to serialize tools overview",
-                                Some(json!({"error": e.to_string()})),
-                            )
-                        })?,
-                        uri,
-                    )]))
+                    serde_json::to_string_pretty(&overview).map_err(|e| {
+                        McpError::internal_error(
+                            "Failed to serialize tools overview",
+                            Some(json!({"error": e.to_string()})),
+                        )
+                    })?,
+                    uri,
+                )]))
             }
             uri if uri.starts_with("nvim-tools://") => {
                 // Handle connection-specific tool resources like "nvim-tools://{connection_id}"
@@ -208,14 +208,14 @@ impl ServerHandler for NeovimMcpServer {
                 });
 
                 Ok(ReadResourceResult::new(vec![ResourceContents::text(
-                        serde_json::to_string_pretty(&result).map_err(|e| {
-                            McpError::internal_error(
-                                "Failed to serialize connection tools",
-                                Some(json!({"error": e.to_string()})),
-                            )
-                        })?,
-                        uri,
-                    )]))
+                    serde_json::to_string_pretty(&result).map_err(|e| {
+                        McpError::internal_error(
+                            "Failed to serialize connection tools",
+                            Some(json!({"error": e.to_string()})),
+                        )
+                    })?,
+                    uri,
+                )]))
             }
             uri if uri.starts_with("nvim-diagnostics://") => {
                 // Parse connection_id from URI pattern using regex
@@ -237,14 +237,14 @@ impl ServerHandler for NeovimMcpServer {
                         "workspace" => {
                             let diagnostics = client.get_workspace_diagnostics().await?;
                             Ok(ReadResourceResult::new(vec![ResourceContents::text(
-                                    serde_json::to_string_pretty(&diagnostics).map_err(|e| {
-                                        McpError::internal_error(
-                                            "Failed to serialize workspace diagnostics",
-                                            Some(json!({"error": e.to_string()})),
-                                        )
-                                    })?,
-                                    uri,
-                                )]))
+                                serde_json::to_string_pretty(&diagnostics).map_err(|e| {
+                                    McpError::internal_error(
+                                        "Failed to serialize workspace diagnostics",
+                                        Some(json!({"error": e.to_string()})),
+                                    )
+                                })?,
+                                uri,
+                            )]))
                         }
                         path if path.starts_with("buffer/") => {
                             let buffer_id = path
@@ -256,14 +256,14 @@ impl ServerHandler for NeovimMcpServer {
 
                             let diagnostics = client.get_buffer_diagnostics(buffer_id).await?;
                             Ok(ReadResourceResult::new(vec![ResourceContents::text(
-                                    serde_json::to_string_pretty(&diagnostics).map_err(|e| {
-                                        McpError::internal_error(
-                                            "Failed to serialize buffer diagnostics",
-                                            Some(json!({"error": e.to_string()})),
-                                        )
-                                    })?,
-                                    uri,
-                                )]))
+                                serde_json::to_string_pretty(&diagnostics).map_err(|e| {
+                                    McpError::internal_error(
+                                        "Failed to serialize buffer diagnostics",
+                                        Some(json!({"error": e.to_string()})),
+                                    )
+                                })?,
+                                uri,
+                            )]))
                         }
                         _ => Err(McpError::resource_not_found(
                             "resource_not_found",

--- a/src/server/resources.rs
+++ b/src/server/resources.rs
@@ -28,15 +28,14 @@ fn new_resource(uri: &str, name: &str, description: Option<&str>) -> Resource {
 impl ServerHandler for NeovimMcpServer {
     #[instrument(skip(self))]
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: None,
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .enable_tool_list_changed()
-                .enable_resources()
-                .build(),
-            ..Default::default()
-        }
+        let mut info = ServerInfo::default();
+        info.instructions = None;
+        info.capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_tool_list_changed()
+            .enable_resources()
+            .build();
+        info
     }
 
     #[instrument(skip(self))]
@@ -112,8 +111,7 @@ impl ServerHandler for NeovimMcpServer {
                     })
                     .collect();
 
-                Ok(ReadResourceResult {
-                    contents: vec![ResourceContents::text(
+                Ok(ReadResourceResult::new(vec![ResourceContents::text(
                         serde_json::to_string_pretty(&connections).map_err(|e| {
                             McpError::internal_error(
                                 "Failed to serialize connections",
@@ -121,8 +119,7 @@ impl ServerHandler for NeovimMcpServer {
                             )
                         })?,
                         uri,
-                    )],
-                })
+                    )]))
             }
             "nvim-tools://" => {
                 // Overview of all tools and their connection mappings
@@ -165,8 +162,7 @@ impl ServerHandler for NeovimMcpServer {
                     "connection_specific_tools": connection_tools
                 });
 
-                Ok(ReadResourceResult {
-                    contents: vec![ResourceContents::text(
+                Ok(ReadResourceResult::new(vec![ResourceContents::text(
                         serde_json::to_string_pretty(&overview).map_err(|e| {
                             McpError::internal_error(
                                 "Failed to serialize tools overview",
@@ -174,8 +170,7 @@ impl ServerHandler for NeovimMcpServer {
                             )
                         })?,
                         uri,
-                    )],
-                })
+                    )]))
             }
             uri if uri.starts_with("nvim-tools://") => {
                 // Handle connection-specific tool resources like "nvim-tools://{connection_id}"
@@ -212,8 +207,7 @@ impl ServerHandler for NeovimMcpServer {
                     "dynamic_count": self.hybrid_router.get_connection_tool_count(connection_id)
                 });
 
-                Ok(ReadResourceResult {
-                    contents: vec![ResourceContents::text(
+                Ok(ReadResourceResult::new(vec![ResourceContents::text(
                         serde_json::to_string_pretty(&result).map_err(|e| {
                             McpError::internal_error(
                                 "Failed to serialize connection tools",
@@ -221,8 +215,7 @@ impl ServerHandler for NeovimMcpServer {
                             )
                         })?,
                         uri,
-                    )],
-                })
+                    )]))
             }
             uri if uri.starts_with("nvim-diagnostics://") => {
                 // Parse connection_id from URI pattern using regex
@@ -243,8 +236,7 @@ impl ServerHandler for NeovimMcpServer {
                     match resource_type {
                         "workspace" => {
                             let diagnostics = client.get_workspace_diagnostics().await?;
-                            Ok(ReadResourceResult {
-                                contents: vec![ResourceContents::text(
+                            Ok(ReadResourceResult::new(vec![ResourceContents::text(
                                     serde_json::to_string_pretty(&diagnostics).map_err(|e| {
                                         McpError::internal_error(
                                             "Failed to serialize workspace diagnostics",
@@ -252,8 +244,7 @@ impl ServerHandler for NeovimMcpServer {
                                         )
                                     })?,
                                     uri,
-                                )],
-                            })
+                                )]))
                         }
                         path if path.starts_with("buffer/") => {
                             let buffer_id = path
@@ -264,8 +255,7 @@ impl ServerHandler for NeovimMcpServer {
                                 })?;
 
                             let diagnostics = client.get_buffer_diagnostics(buffer_id).await?;
-                            Ok(ReadResourceResult {
-                                contents: vec![ResourceContents::text(
+                            Ok(ReadResourceResult::new(vec![ResourceContents::text(
                                     serde_json::to_string_pretty(&diagnostics).map_err(|e| {
                                         McpError::internal_error(
                                             "Failed to serialize buffer diagnostics",
@@ -273,8 +263,7 @@ impl ServerHandler for NeovimMcpServer {
                                         )
                                     })?,
                                     uri,
-                                )],
-                            })
+                                )]))
                         }
                         _ => Err(McpError::resource_not_found(
                             "resource_not_found",


### PR DESCRIPTION
### Motivation
- Upstream `rmcp` types were marked `#[non_exhaustive]` in v1.6, causing compilation errors when constructing those models via struct expressions.
- Update code to use stable constructors/builders or `Default`+mutation to remain compatible with future `rmcp` fields.

### Description
- Replace direct `ServerInfo` struct literal with `ServerInfo::default()` and then set fields (in `src/server/resources.rs`).
- Use `ReadResourceResult::new(...)` instead of constructing `ReadResourceResult` with a struct expression to avoid non-exhaustive field errors (in `src/server/resources.rs`).
- Replace manual `ToolAnnotations { ... }` construction with `ToolAnnotations::with_title(...)` for dynamic tools (in `src/server/hybrid_router.rs`).
- Build static-tool call requests via `CallToolRequestParams::new(...).with_arguments(...)` instead of struct literals (in `src/server/hybrid_router.rs`).
- Update test helpers to use `CallToolRequestParams::new` and `ReadResourceRequestParams::new` (in `src/server/integration_tests.rs`).
- Initialize `StreamableHttpServerConfig` from `default()` and mutate the field instead of using a struct update expression (in `src/main.rs`).

### Testing
- Ran `cargo check -q`, which completed successfully and validated the compile-time compatibility changes.
- Ran `cargo test -q`, which now compiles and exercises integration tests; unit tests passed but many integration tests failed (39 passed; 47 failed) due to missing runtime test prerequisites rather than code regressions, specifically a missing `nvim` binary and the precompiled server binary required by some integration helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f564f636b0832eba0902a923d4fb98)